### PR TITLE
Fix issue with line-height when deleting/merging paras in Chrome

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -109,7 +109,9 @@ define(function () {
             var range = selection.range;
 
             if (range.collapsed) {
-              var containerPara = selection.getContaining('P');
+              var containerPara = selection.getContaining(function (node) {
+                return node.nodeName === 'P';
+              });
               if (containerPara) {
                 // Store the caret position
                 selection.placeMarkers();

--- a/test/main.js
+++ b/test/main.js
@@ -918,7 +918,7 @@ browsers.forEach(function (browser) {
 
               it('should not wrap the remaining paragraph in <span> with line-height', function() {
                 return scribeNode.getInnerHTML().then(function (innerHTML) {
-                  expect(innerHTML).to.have.html('<p>hello<bogus-br></p>');
+                  expect(innerHTML).to.have.html('<p>hello<chrome-bogus-br></p>');
                 });
               });
             });
@@ -934,7 +934,7 @@ browsers.forEach(function (browser) {
 
               it('should not wrap the remaining paragraph in <span> with line-height', function() {
                 return scribeNode.getInnerHTML().then(function (innerHTML) {
-                  expect(innerHTML).to.have.html('<p>hello<bogus-br></p>');
+                  expect(innerHTML).to.have.html('<p>hello<chrome-bogus-br></p>');
                 });
               });
             });
@@ -950,7 +950,7 @@ browsers.forEach(function (browser) {
 
               it('should not add a line-height to the <em>', function() {
                 return scribeNode.getInnerHTML().then(function (innerHTML) {
-                  expect(innerHTML).to.have.html('<p><em>hello</em><bogus-br></p>');
+                  expect(innerHTML).to.have.html('<p><em>hello</em><chrome-bogus-br></p>');
                 });
               });
             });
@@ -966,7 +966,7 @@ browsers.forEach(function (browser) {
 
               it('should not add a line-height to the <em>', function() {
                 return scribeNode.getInnerHTML().then(function (innerHTML) {
-                  expect(innerHTML).to.have.html('<p><em>hello</em><bogus-br></p>');
+                  expect(innerHTML).to.have.html('<p><em>hello</em><chrome-bogus-br></p>');
                 });
               });
             });
@@ -983,7 +983,7 @@ browsers.forEach(function (browser) {
 
               it('should not add a span or a line-height to the <em>', function() {
                 return scribeNode.getInnerHTML().then(function (innerHTML) {
-                  expect(innerHTML).to.have.html('<p>text <em>hello</em> world!<bogus-br></p>');
+                  expect(innerHTML).to.have.html('<p>text <em>hello</em> world!<chrome-bogus-br></p>');
                 });
               });
             });


### PR DESCRIPTION
Bit of a hefty patch to fix the line-height issue in Chrome.

Comes with a suite of tests to prove the problem is gone.

Note the various TODOs, in particular we probably want to run this in a transaction to record any change in the undo manager, but I didn't add it as more often than not the patch would be a noop (no line-height to cleanup). I think we can lose the tiny bit of history for now until @OliverJAsh enlightens me.

/cc @OliverJAsh let me know if you have time to check, else might work with Rob to release and roll out in the coming hours.
