### PR TITLE
Fix console logging for undo manager

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -21,7 +21,7 @@ define([
   events,
   Api,
   buildTransactionManager,
-  UndoManager
+  buildUndoManager
 ) {
 
   'use strict';
@@ -40,10 +40,10 @@ define([
     this.api = new Api(this);
 
     var TransactionManager = buildTransactionManager(this);
-    this.undoManager = new UndoManager({
-      isDebugModeEnabled: this.options.debug
-    });
     this.transactionManager = new TransactionManager();
+    
+    var UndoManager = buildUndoManager(this);
+    this.undoManager = new UndoManager();
 
     this.el.addEventListener('input', function () {
       /**
@@ -259,6 +259,10 @@ define([
     // TODO: error if the selection is not within the Scribe instance? Or
     // focus the Scribe instance if it is not already focused?
     this.getCommand('insertHTML').execute(this.formatter.format(html));
+  };
+
+  Scribe.prototype.isDebugModeEnabled = function () {
+    return this.options.debug;
   };
 
   // TODO: abstract

--- a/src/undo-manager.js
+++ b/src/undo-manager.js
@@ -2,39 +2,42 @@ define(function () {
 
   'use strict';
 
-  function UndoManager(options) {
-    this.position = 0;
-    this.stack = [];
-    this.debug = (options.isDebugModeEnabled) ? true : false;
-  }
+  return function (scribe) {
 
-  UndoManager.prototype.maxStackSize = 100;
-
-  UndoManager.prototype.push = function (item) {
-    if (this.debug) {
-      console.log('UndoManager.push: %s', item);
+    function UndoManager() {
+      this.position = 0;
+      this.stack = [];
+      this.debug = scribe.isDebugModeEnabled();
     }
-    this.stack.length = ++this.position;
-    this.stack.push(item);
 
-    while (this.stack.length > this.maxStackSize) {
-      this.stack.shift();
-      --this.position;
-    }
+    UndoManager.prototype.maxStackSize = 100;
+
+    UndoManager.prototype.push = function (item) {
+      if (this.debug) {
+        console.log('UndoManager.push: %s', item);
+      }
+      this.stack.length = ++this.position;
+      this.stack.push(item);
+
+      while (this.stack.length > this.maxStackSize) {
+        this.stack.shift();
+        --this.position;
+      }
+    };
+
+    UndoManager.prototype.undo = function () {
+      if (this.position > 1) {
+        return this.stack[--this.position];
+      }
+    };
+
+    UndoManager.prototype.redo = function () {
+      if (this.position < this.stack.length - 1) {
+        return this.stack[++this.position];
+      }
+    };
+
+    return UndoManager;
   };
-
-  UndoManager.prototype.undo = function () {
-    if (this.position > 1) {
-      return this.stack[--this.position];
-    }
-  };
-
-  UndoManager.prototype.redo = function () {
-    if (this.position < this.stack.length - 1) {
-      return this.stack[++this.position];
-    }
-  };
-
-  return UndoManager;
 
 });


### PR DESCRIPTION
This makes the undo manager only log output to console when `?debug` is in the URL. 

This is for a few reasons, namely:
- it gets annoying quickly when the entire console is taken up by a large text output
- when typing in Scribe with the devtools console open, there's a noticeable flicker/lag when typing as the console is written to (switching to another devtools tab removes this effect)

I think it's a nice idea in general to have a configurable "dev mode" override for logging important stuff, and one which isn't on by default. We could use this approach in Composer, too (currently Composer logs the asset mapping on load, which is probably only needed during debugging) cc @theefer 
