### PR TITLE
Unapply blockquote when <enter> is pressed on a new line

### DIFF
--- a/src/plugins/blockquote-command.js
+++ b/src/plugins/blockquote-command.js
@@ -30,6 +30,34 @@ define(function () {
       };
 
       scribe.commands.blockquote = blockquoteCommand;
+
+      /**
+       * If the paragraphs option is set to true, we unapply the blockquote on
+       * <enter> keypresses if the caret is on a new line.
+       */
+      if (scribe.allowsBlockElements()) {
+        scribe.el.addEventListener('keydown', function (event) {
+          if (event.keyCode === 13) { // enter
+
+            var command = scribe.getCommand('blockquote');
+            if (command.queryState()) {
+              var selection = new scribe.api.Selection();
+              var containerPElement = selection.getContaining(function (node) {
+                return node.nodeName === 'P';
+              });
+              // TODO: abstract
+              var isCaretOnNewLine =
+                (containerPElement.nodeName === 'P'
+                 && (containerPElement.innerHTML === '<br>'
+                     || containerPElement.innerHTML.trim() === ''));
+              if (isCaretOnNewLine) {
+                event.preventDefault();
+                command.execute();
+              }
+            }
+          }
+        });
+      }
     };
   };
 

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -91,7 +91,6 @@ define(function () {
         });
       }
 
-
       /**
        * Run formatters on paste
        */

--- a/test/main.js
+++ b/test/main.js
@@ -251,6 +251,32 @@ describe('P mode', function () {
     });
   });
 
+  describe('blockquotes', function () {
+    beforeEach(function () {
+      return driver.executeAsyncScript(function (done) {
+        require(['plugins/blockquote-command'], function (blockquoteCommand) {
+          window.scribe.use(blockquoteCommand());
+          done();
+        });
+      });
+    });
+
+    // The BR node denotes where the user will type.
+    givenContentOf('<blockquote><p>|<br></p></blockquote>', function () {
+      when('the user presses <enter>', function () {
+        beforeEach(function () {
+          return scribeNode.sendKeys(webdriver.Key.ENTER);
+        });
+
+        it('should delete the blockquote and insert an empty P element', function () {
+          return scribeNode.getInnerHTML().then(function (innerHTML) {
+            expect(innerHTML).to.have.html('<p><bogus-br></p>');
+          });
+        });
+      });
+    });
+  });
+
   describe('lists', function () {
     // The BR node denotes where the user will type.
     givenContentOf('<ul><li>|<br></li></ul>', function () {


### PR DESCRIPTION
I plan to abstract `isCaretOnNewLine` when this is merged.
