### PR TITLE
Return focus to the contenteditable before executing commands inside toolbar event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Playground: http://jsbin.com/iwEWUXo/2/edit?js,console,output
 * Firefox: When the `contenteditable` element is a custom element, an error is
   thrown when trying to apply one of the following commands.
   As per: http://jsbin.com/etepiPOn/1/edit?html,css,js,console,output
+* Chrome has some magic to re-focus the `contenteditable` when a command is
+  executed: http://jsbin.com/papi/1/edit?html,js,output
   `insertOrderedList`, insertUnorderedList`, `indent`, `outdent`, `formatBlock`
 * "`insertBrOnReturn`": http://jsbin.com/IQUraXA/1/edit?html,js,output
 * "`insertHTML`":

--- a/src/plugins/toolbar.js
+++ b/src/plugins/toolbar.js
@@ -11,9 +11,19 @@ define(function () {
         var command = scribe.getCommand(button.dataset.commandName);
 
         button.addEventListener('click', function () {
-          command.execute();
-          // Chrome focuses the scribe automatically. Firefox does not.
+          /**
+           * Focus will have been taken away from the Scribe instance when
+           * clicking on a button. It is important that we focus the instance
+           * again before executing the command, because it might rely on
+           * selection data.
+           */
           scribe.el.focus();
+          command.execute();
+          /**
+           * Chrome has a bit of magic to re-focus the `contenteditable` when a
+           * command is executed.
+           * As per: http://jsbin.com/papi/1/edit?html,js,output
+           */
         });
 
         // Keep the state of toolbar buttons in sync with the current selection.


### PR DESCRIPTION
This fixes a bug where the selection would change when executing a command, i.e.
clicking the `blockquote` button in the toolbar.
