### PR TITLE
Fix Selection.isCaretOnNewLine to return false if P element is not found

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -100,10 +100,14 @@ define(function () {
       });
       // We must do `innerHTML.trim()` to avoid weird Firefox bug:
       // http://stackoverflow.com/questions/3676927/why-if-element-innerhtml-is-not-working-in-firefox
-      var containerPElementInnerHTML = containerPElement.innerHTML.trim();
-      return containerPElement && (containerPElement.nodeName === 'P'
-                                   && (containerPElementInnerHTML === '<br>'
-                                       || containerPElementInnerHTML === ''));
+      if (containerPElement) {
+        var containerPElementInnerHTML = containerPElement.innerHTML.trim();
+        return (containerPElement.nodeName === 'P'
+                && (containerPElementInnerHTML === '<br>'
+                    || containerPElementInnerHTML === ''));
+      } else {
+        return false;
+      }
     };
 
     return Selection;


### PR DESCRIPTION
Was throwing error.
