### PR TITLE
Fix curly quotes in parentheses

### DIFF
--- a/src/plugins/scribe-plugin-curly-quotes.js
+++ b/src/plugins/scribe-plugin-curly-quotes.js
@@ -56,12 +56,8 @@ define(function () {
       }
 
       function wordBeforeSelectedRange() {
-        var prevChar = charBeforeSelectedRange();
-        return (
-          prevChar !== ' ' &&
-          prevChar !== NON_BREAKING_SPACE &&
-          typeof prevChar !== 'undefined'
-        );
+        var prevChar = charBeforeSelectedRange() || '';
+        return isWordCharacter(prevChar);
       }
 
       function charBeforeSelectedRange() {
@@ -74,6 +70,10 @@ define(function () {
         var selection = new scribe.api.Selection();
         var context = selection.range.commonAncestorContainer.textContent;
         return context[selection.range.endOffset];
+      }
+
+      function isWordCharacter(character) {
+          return /[^\s()]/.test(character);
       }
 
       /** Delete any selected text, insert text instead */
@@ -123,8 +123,8 @@ define(function () {
           next = next || '';
           var isStart = ! prev;
           var isEnd = ! next;
-          var hasCharsBefore = /[^\s()]/.test(prev);
-          var hasCharsAfter = /[^\s()]/.test(next);
+          var hasCharsBefore = isWordCharacter(prev);
+          var hasCharsAfter  = isWordCharacter(next);
           // Optimistic heuristic, would need to look at DOM structure
           // (esp block vs inline elements) for more robust inference
           if (hasCharsBefore || (isStart && ! hasCharsAfter && ! isEnd)) {

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -1769,6 +1769,31 @@ describe('curly quotes plugin', function () {
     });
   });
 
+  given('the caret is after an opening parenthesis', function () {
+    beforeEach(function () {
+      return scribeNode.sendKeys('(');
+    });
+
+    when('the user types ascii double quote', function () {
+      beforeEach(function () {
+        return scribeNode.sendKeys('"');
+      });
+
+      it('should insert an opening curly double quote', function () {
+        // FIXME:
+        if (seleniumBugs.chrome.specialCharacters) { return; }
+        // FIXME:
+        if (seleniumBugs.firefox.curlyQuotes) { return; }
+
+        return scribeNode.getInnerHTML().then(function (innerHTML) {
+          // Chrome (30): '<p>Hello.”</p>'
+          // Firefox (23, 24, 25): '<p>“Hello.”””<br></p>'
+          expect(innerHTML).to.have.html('<p>(“<firefox-bogus-br></p>');
+        });
+      });
+    });
+  });
+
   given('the caret is after the end of a word', function () {
     beforeEach(function () {
       return scribeNode.sendKeys('Hello '); // Note the space


### PR DESCRIPTION
I've noticed this in live content, curly quotes after opening parentheses are wrong (closing). This fixes the problem both on type and paste.
