### PR TITLE
Workaround timeouts due to Sauce Labs concurrency limits

### DIFF
--- a/test/runner.js
+++ b/test/runner.js
@@ -9,7 +9,13 @@ var counts = {
   fail: 0
 };
 
-mocha.timeout(20000);
+/**
+ * FIXME: We have to set a ridiculous timeout (20 minutes) because Travis’
+ * concurrent builds will sometimes exceed Sauce Labs’ concurrency. We should
+ * track the following issue to add an option to Travis for limiting
+ * concurrency: https://github.com/travis-ci/travis-ci/issues/1963
+ */
+mocha.timeout(1200000);
 mocha.reporter('spec');
 mocha.addFile(__dirname + '/main.spec.js');
 


### PR DESCRIPTION
This is much more of a problem now that we have switched to the Open Sauce plan
on Sauce Labs, which only allows 3 concurrent sessions at a time (down from 10).
On the other hand, it is free and we have unlimited minutes.
