### PR TITLE
Do not needlessly run formatters when executing `insertHTML` command

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -275,7 +275,7 @@ define([
   Scribe.prototype.insertHTML = function (html) {
     // TODO: error if the selection is not within the Scribe instance? Or
     // focus the Scribe instance if it is not already focused?
-    this.getCommand('insertHTML').execute(this.htmlFormatter.format(html));
+    this.getCommand('insertHTML').execute(html);
   };
 
   Scribe.prototype.isDebugModeEnabled = function () {

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -476,7 +476,7 @@ describe('formatters', function () {
 
           it('should replace the non-breaking space character with a normal space', function () {
             return scribeNode.getInnerHTML().then(function (innerHTML) {
-              expect(innerHTML).to.have.html('<p>1 2</p>');
+              expect(innerHTML).to.have.html('<p>1 2<chrome-bogus-br></p>');
             });
           });
         });


### PR DESCRIPTION
The formatters are already run thanks to the `MutationObserver`.
