### PR TITLE
Do not run formatters when calling `scribe.setContent`

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -279,7 +279,7 @@ define([
       content = content + '<br>';
     }
 
-    this.setHTML(this.htmlFormatter.format(content));
+    this.setHTML(content);
 
     this.trigger('content-changed');
   };


### PR DESCRIPTION
Now redundant because of mutation observers.
