### PR TITLE
Compatibility with IE, contenteditables in iframes, and more dynamic activation/deactivation of Scribe

### DIFF
--- a/src/api/command-patch.js
+++ b/src/api/command-patch.js
@@ -9,16 +9,16 @@ define(function () {
 
     CommandPatch.prototype.execute = function (value) {
       scribe.transactionManager.run(function () {
-        document.execCommand(this.commandName, false, value || null);
+        scribe.targetWindow.document.execCommand(this.commandName, false, value || null);
       }.bind(this));
     };
 
     CommandPatch.prototype.queryState = function () {
-      return document.queryCommandState(this.commandName);
+      return scribe.targetWindow.document.queryCommandState(this.commandName);
     };
 
     CommandPatch.prototype.queryEnabled = function () {
-      return document.queryCommandEnabled(this.commandName);
+      return scribe.targetWindow.document.queryCommandEnabled(this.commandName);
     };
 
     return CommandPatch;

--- a/src/api/command.js
+++ b/src/api/command.js
@@ -13,7 +13,7 @@ define(function () {
         this.patch.execute(value);
       } else {
         scribe.transactionManager.run(function () {
-          document.execCommand(this.commandName, false, value || null);
+          scribe.targetWindow.document.execCommand(this.commandName, false, value || null);
         }.bind(this));
       }
     };
@@ -22,7 +22,7 @@ define(function () {
       if (this.patch) {
         return this.patch.queryState();
       } else {
-        return document.queryCommandState(this.commandName);
+        return scribe.targetWindow.document.queryCommandState(this.commandName);
       }
     };
 
@@ -30,7 +30,7 @@ define(function () {
       if (this.patch) {
         return this.patch.queryEnabled();
       } else {
-        return document.queryCommandEnabled(this.commandName);
+        return scribe.targetWindow.document.queryCommandEnabled(this.commandName);
       }
     };
 

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -4,7 +4,7 @@ define(function () {
 
   return function (scribe) {
     function Selection() {
-      this.selection = window.getSelection();
+      this.selection = scribe.targetWindow.getSelection();
 
       if (this.selection.rangeCount) {
         this.range = this.selection.getRangeAt(0);
@@ -19,9 +19,9 @@ define(function () {
     };
 
     Selection.prototype.placeMarkers = function () {
-      var startMarker = document.createElement('em');
+      var startMarker = scribe.targetWindow.document.createElement('em');
       startMarker.classList.add('scribe-marker');
-      var endMarker = document.createElement('em');
+      var endMarker = scribe.targetWindow.document.createElement('em');
       endMarker.classList.add('scribe-marker');
 
       // End marker

--- a/src/plugins/core/commands/insert-html.js
+++ b/src/plugins/core/commands/insert-html.js
@@ -30,7 +30,7 @@ define([
           // TODO: This should probably be a part of HTML Janitor, or some other
           // formatter.
           scribe.transactionManager.run(function () {
-            var bin = document.createElement('div');
+            var bin = scribe.targetWindow.document.createElement('div');
             bin.innerHTML = value;
 
             wrapChildNodes(bin);
@@ -71,7 +71,7 @@ define([
               });
 
               consecutiveInlineElementsAndTextNodes.forEach(function (nodes) {
-                var pElement = document.createElement('p');
+                var pElement = scribe.targetWindow.document.createElement('p');
                 nodes[0].parentNode.insertBefore(pElement, nodes[0]);
                 nodes.forEach(function (node) {
                   pElement.appendChild(node);
@@ -83,7 +83,7 @@ define([
 
             // Traverse the tree, wrapping child nodes as we go.
             function traverse(parentNode) {
-              var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
+              var treeWalker = scribe.targetWindow.document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
               var node = treeWalker.firstChild();
 
               while (node) {

--- a/src/plugins/core/commands/insert-html.js
+++ b/src/plugins/core/commands/insert-html.js
@@ -83,7 +83,7 @@ define([
 
             // Traverse the tree, wrapping child nodes as we go.
             function traverse(parentNode) {
-              var treeWalker = scribe.targetWindow.document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
+              var treeWalker = scribe.targetWindow.document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
               var node = treeWalker.firstChild();
 
               while (node) {

--- a/src/plugins/core/commands/insert-list.js
+++ b/src/plugins/core/commands/insert-list.js
@@ -19,7 +19,7 @@ define(function () {
       InsertListCommand.prototype.execute = function (value) {
         function splitList(listItemElements) {
           if (listItemElements.length > 0) {
-            var newListNode = document.createElement(listNode.nodeName);
+            var newListNode = scribe.targetWindow.document.createElement(listNode.nodeName);
 
             listItemElements.forEach(function (listItemElement) {
               newListNode.appendChild(listItemElement);
@@ -57,7 +57,7 @@ define(function () {
 
               selection.placeMarkers();
 
-              var pNode = document.createElement('p');
+              var pNode = scribe.targetWindow.document.createElement('p');
               pNode.innerHTML = listItemElement.innerHTML;
 
               listNode.parentNode.insertBefore(pNode, listNode.nextElementSibling);
@@ -91,9 +91,9 @@ define(function () {
               // afterwards.
               selection.placeMarkers();
 
-              var documentFragment = document.createDocumentFragment();
+              var documentFragment = scribe.targetWindow.document.createDocumentFragment();
               selectedListItemElements.forEach(function (listItemElement) {
-                var pElement = document.createElement('p');
+                var pElement = scribe.targetWindow.document.createElement('p');
                 pElement.innerHTML = listItemElement.innerHTML;
                 documentFragment.appendChild(pElement);
               });

--- a/src/plugins/core/commands/redo.js
+++ b/src/plugins/core/commands/redo.js
@@ -20,12 +20,17 @@ define(function () {
 
       scribe.commands.redo = redoCommand;
 
-      scribe.el.addEventListener('keydown', function (event) {
+      scribe.el.addEventListener('keydown', handleRedo);
+      scribe.on('deactivated', function() {
+        scribe.el.removeEventListener('keydown', handleRedo);
+      });
+
+      function handleRedo(event) {
         if (event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {
           event.preventDefault();
           redoCommand.execute();
         }
-      });
+      }
     };
   };
 

--- a/src/plugins/core/commands/undo.js
+++ b/src/plugins/core/commands/undo.js
@@ -20,13 +20,18 @@ define(function () {
 
       scribe.commands.undo = undoCommand;
 
-      scribe.el.addEventListener('keydown', function (event) {
+      scribe.el.addEventListener('keydown', handleUndo);
+      scribe.on('deactivated', function() {
+        scribe.el.removeEventListener('keydown', handleUndo);
+      });
+
+      function handleUndo(event) {
         // TODO: use lib to abstract meta/ctrl keys?
         if (! event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {
           event.preventDefault();
           undoCommand.execute();
         }
-      });
+      }
     };
   };
 

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -103,7 +103,13 @@ define([
        * I also don't like how it has the authority to perform `event.preventDefault`.
        */
 
-      scribe.el.addEventListener('paste', function handlePaste(event) {
+      scribe.el.addEventListener('paste', handlePaste);
+      scribe.on('deactivated', function() {
+        scribe.el.removeEventListener('paste', handlePaste);
+      });
+
+      function handlePaste(event) {
+
         /**
          * Browsers without the Clipboard API (specifically `ClipboardEvent.clipboardData`)
          * will execute the second branch here.
@@ -161,7 +167,7 @@ define([
             scribe.insertHTML(data);
           }, 1);
         }
-      });
+      }
 
     };
   };

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -40,8 +40,8 @@ define([
                 scribe.transactionManager.run(function () {
                   // Default P
                   // TODO: Abstract somewhere
-                  var pNode = document.createElement('p');
-                  var brNode = document.createElement('br');
+                  var pNode = scribe.targetWindow.document.createElement('p');
+                  var brNode = scribe.targetWindow.document.createElement('br');
                   pNode.appendChild(brNode);
 
                   headingNode.parentNode.insertBefore(pNode, headingNode.nextElementSibling);
@@ -140,8 +140,8 @@ define([
           // Store the caret position
           selection.placeMarkers();
 
-          var bin = document.createElement('div');
-          document.body.appendChild(bin);
+          var bin = scribe.targetWindow.document.createElement('div');
+          scribe.targetWindow.document.body.appendChild(bin);
           bin.setAttribute('contenteditable', true);
           bin.focus();
 

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -158,6 +158,8 @@ define([
           selection.placeMarkers();
 
           var bin = scribe.targetWindow.document.createElement('div');
+          bin.style.maxHeight = '1px';
+          bin.style.overflow = 'hidden';
           scribe.targetWindow.document.body.appendChild(bin);
           bin.setAttribute('contenteditable', true);
           bin.focus();

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -13,7 +13,8 @@ define([
        * keyboard navigation inside a heading to ensure a P element is created.
        */
       if (scribe.allowsBlockElements()) {
-        scribe.el.addEventListener('keydown', function (event) {
+
+        var handlePtagCreation = function(event) {
           if (event.keyCode === 13) { // enter
 
             var selection = new scribe.api.Selection();
@@ -56,6 +57,11 @@ define([
               }
             }
           }
+        };
+
+        scribe.el.addEventListener('keydown', handlePtagCreation);
+        scribe.on('deactivated', function() {
+          scribe.el.removeEventListener('keydown', handlePtagCreation);
         });
       }
 
@@ -64,7 +70,7 @@ define([
        * keyboard navigation inside list item nodes.
        */
       if (scribe.allowsBlockElements()) {
-        scribe.el.addEventListener('keydown', function (event) {
+        var handleLItagCreation = function(event) {
           if (event.keyCode === 13 || event.keyCode === 8) { // enter || backspace
 
             var selection = new scribe.api.Selection();
@@ -91,6 +97,11 @@ define([
               }
             }
           }
+        };
+
+        scribe.el.addEventListener('keydown', handleLItagCreation);
+        scribe.on('deactivated', function() {
+          scribe.el.removeEventListener('keydown', handleLItagCreation);
         });
       }
 

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -164,7 +164,7 @@ define([
 
           // Wait for the paste to happen (next loop?)
           setTimeout(function () {
-            data = bin.innerHTML;
+            var data = bin.innerHTML;
             bin.parentNode.removeChild(bin);
 
             // Restore the caret position

--- a/src/plugins/core/inline-elements-mode.js
+++ b/src/plugins/core/inline-elements-mode.js
@@ -4,7 +4,7 @@ define(function () {
 
   // TODO: abstract
   function hasContent(rootNode) {
-    var treeWalker = scribe.targetWindow.document.createTreeWalker(rootNode);
+    var treeWalker = scribe.targetWindow.document.createTreeWalker(rootNode, NodeFilter.SHOW_ALL, null, false);
 
     while (treeWalker.nextNode()) {
       if (treeWalker.currentNode) {

--- a/src/plugins/core/inline-elements-mode.js
+++ b/src/plugins/core/inline-elements-mode.js
@@ -4,7 +4,7 @@ define(function () {
 
   // TODO: abstract
   function hasContent(rootNode) {
-    var treeWalker = document.createTreeWalker(rootNode);
+    var treeWalker = scribe.targetWindow.document.createTreeWalker(rootNode);
 
     while (treeWalker.nextNode()) {
       if (treeWalker.currentNode) {
@@ -49,7 +49,7 @@ define(function () {
                 scribe.el.removeChild(scribe.el.lastChild);
               }
 
-              var brNode = document.createElement('br');
+              var brNode = scribe.targetWindow.document.createElement('br');
 
               range.insertNode(brNode);
               // After inserting the BR into the range is no longer collapsed, so
@@ -87,7 +87,7 @@ define(function () {
               // If there is not already a right hand side content we need to
               // insert a bogus BR element.
               if (! hasContent(contentToEndFragment)) {
-                var bogusBrNode = document.createElement('br');
+                var bogusBrNode = scribe.targetWindow.document.createElement('br');
                 range.insertNode(bogusBrNode);
               }
 

--- a/src/plugins/core/inline-elements-mode.js
+++ b/src/plugins/core/inline-elements-mode.js
@@ -27,7 +27,7 @@ define(function () {
        * https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#the-insertlinebreak-command
        * As per: http://jsbin.com/IQUraXA/1/edit?html,js,output
        */
-      scribe.el.addEventListener('keydown', function (event) {
+      var handleLineBreak = function (event) {
         if (event.keyCode === 13) { // enter
           var selection = new scribe.api.Selection();
           var range = selection.range;
@@ -101,7 +101,12 @@ define(function () {
             });
           }
         }
-      }.bind(this));
+      }.bind(this);
+
+      scribe.el.addEventListener('keydown', handleLineBreak);
+      scribe.on('deactivated', function() {
+        scribe.el.removeEventListener('keydown', handleLineBreak);
+      });
 
       if (scribe.getHTML().trim() === '') {
         // Bogus BR element for Firefox — see explanation above.

--- a/src/plugins/core/patches/commands/indent.js
+++ b/src/plugins/core/patches/commands/indent.js
@@ -29,7 +29,7 @@ define(function () {
           if (isCaretOnNewLine) {
             // FIXME: this text node is left behind. Tidy it up somehow,
             // or don't use it at all.
-            var textNode = document.createTextNode(INVISIBLE_CHAR);
+            var textNode = scribe.targetWindow.document.createTextNode(INVISIBLE_CHAR);
 
             range.insertNode(textNode);
 

--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -30,7 +30,7 @@ define(function () {
             if (!node) { return; }
 
             do {
-              if (node.nodeName === 'SPAN') {
+              if (node.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon')) {
                 new scribe.api.Element(parentNode).unwrap(node);
               } else {
                 /**

--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -31,10 +31,10 @@ define(function () {
 
             do {
               if (node.nodeName === 'SPAN' &&
-                  node.nodeClass != 'font-size-smaller' &&
-                  node.nodeClass != 'font-size-larger' &&
-                  node.nodeClass != 'pplr-icon' &&
-                  node.nodeClass != 'pplr-accent') {
+                  node.className != 'font-size-smaller' &&
+                  node.className != 'font-size-larger' &&
+                  node.className != 'pplr-icon' &&
+                  node.className != 'pplr-accent') {
                 new scribe.api.Element(parentNode).unwrap(node);
               } else {
                 /**

--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -25,7 +25,7 @@ define(function () {
           sanitize(scribe.el);
 
           function sanitize(parentNode) {
-            var treeWalker = scribe.targetWindow.document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
+            var treeWalker = scribe.targetWindow.document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
             var node = treeWalker.firstChild();
             if (!node) { return; }
 

--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -25,7 +25,7 @@ define(function () {
           sanitize(scribe.el);
 
           function sanitize(parentNode) {
-            var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
+            var treeWalker = scribe.targetWindow.document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
             var node = treeWalker.firstChild();
             if (!node) { return; }
 

--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -30,7 +30,11 @@ define(function () {
             if (!node) { return; }
 
             do {
-              if (node.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon') && !$(node).hasClass('pplr-accent')) {
+              if (node.nodeName === 'SPAN' &&
+                  node.nodeClass != 'font-size-smaller' &&
+                  node.nodeClass != 'font-size-larger' &&
+                  node.nodeClass != 'pplr-icon' &&
+                  node.nodeClass != 'pplr-accent') {
                 new scribe.api.Element(parentNode).unwrap(node);
               } else {
                 /**

--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -30,7 +30,7 @@ define(function () {
             if (!node) { return; }
 
             do {
-              if (node.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon')) {
+              if (node.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon') && !$(node).hasClass('pplr-accent')) {
                 new scribe.api.Element(parentNode).unwrap(node);
               } else {
                 /**

--- a/src/plugins/core/patches/commands/insert-list.js
+++ b/src/plugins/core/patches/commands/insert-list.js
@@ -58,7 +58,11 @@ define(function () {
               // iterate over it
               var listItemElementChildNodes = Array.prototype.slice.call(listItemElement.childNodes);
               listItemElementChildNodes.forEach(function(listElementChildNode) {
-                if (listElementChildNode.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon') && !$(node).hasClass('pplr-accent')) {
+                if (listElementChildNode.nodeName === 'SPAN' &&
+                    listElementChildNode.nodeClass != 'font-size-smaller' &&
+                    listElementChildNode.nodeClass != 'font-size-larger' &&
+                    listElementChildNode.nodeClass != 'pplr-icon' &&
+                    listElementChildNode.nodeClass != 'pplr-accent') {
                   // Unwrap any SPAN that has been inserted
                   var spanElement = listElementChildNode;
                   new scribe.api.Element(listItemElement).unwrap(spanElement);

--- a/src/plugins/core/patches/commands/insert-list.js
+++ b/src/plugins/core/patches/commands/insert-list.js
@@ -58,7 +58,7 @@ define(function () {
               // iterate over it
               var listItemElementChildNodes = Array.prototype.slice.call(listItemElement.childNodes);
               listItemElementChildNodes.forEach(function(listElementChildNode) {
-                if (listElementChildNode.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon')) {
+                if (listElementChildNode.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon') && !$(node).hasClass('pplr-accent')) {
                   // Unwrap any SPAN that has been inserted
                   var spanElement = listElementChildNode;
                   new scribe.api.Element(listItemElement).unwrap(spanElement);

--- a/src/plugins/core/patches/commands/insert-list.js
+++ b/src/plugins/core/patches/commands/insert-list.js
@@ -58,7 +58,7 @@ define(function () {
               // iterate over it
               var listItemElementChildNodes = Array.prototype.slice.call(listItemElement.childNodes);
               listItemElementChildNodes.forEach(function(listElementChildNode) {
-                if (listElementChildNode.nodeName === 'SPAN') {
+                if (listElementChildNode.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon')) {
                   // Unwrap any SPAN that has been inserted
                   var spanElement = listElementChildNode;
                   new scribe.api.Element(listItemElement).unwrap(spanElement);

--- a/src/plugins/core/patches/commands/insert-list.js
+++ b/src/plugins/core/patches/commands/insert-list.js
@@ -59,10 +59,10 @@ define(function () {
               var listItemElementChildNodes = Array.prototype.slice.call(listItemElement.childNodes);
               listItemElementChildNodes.forEach(function(listElementChildNode) {
                 if (listElementChildNode.nodeName === 'SPAN' &&
-                    listElementChildNode.nodeClass != 'font-size-smaller' &&
-                    listElementChildNode.nodeClass != 'font-size-larger' &&
-                    listElementChildNode.nodeClass != 'pplr-icon' &&
-                    listElementChildNode.nodeClass != 'pplr-accent') {
+                    listElementChildNode.className != 'font-size-smaller' &&
+                    listElementChildNode.className != 'font-size-larger' &&
+                    listElementChildNode.className != 'pplr-icon' &&
+                    listElementChildNode.className != 'pplr-accent') {
                   // Unwrap any SPAN that has been inserted
                   var spanElement = listElementChildNode;
                   new scribe.api.Element(listItemElement).unwrap(spanElement);

--- a/src/plugins/core/patches/commands/outdent.js
+++ b/src/plugins/core/patches/commands/outdent.js
@@ -61,7 +61,7 @@ define(function () {
               var nextSiblingNodes = (new scribe.api.Node(pNode)).nextAll();
 
               if (nextSiblingNodes.length) {
-                var newContainerNode = document.createElement(blockquoteNode.nodeName);
+                var newContainerNode = scribe.targetWindow.document.createElement(blockquoteNode.nodeName);
 
                 nextSiblingNodes.forEach(function (siblingNode) {
                   newContainerNode.appendChild(siblingNode);

--- a/src/plugins/core/patches/empty-when-deleting.js
+++ b/src/plugins/core/patches/empty-when-deleting.js
@@ -51,7 +51,7 @@ define(function () {
        * @return {string}
        */
       function serialiseRangeToHTML(range) {
-        var div = document.createElement('div');
+        var div = scribe.targetWindow.document.createElement('div');
         var contents = range.cloneContents();
         div.appendChild(contents);
         return div.innerHTML;
@@ -68,7 +68,7 @@ define(function () {
         // them with the stricly equality operator.
         var serialisedSelection = serialiseRangeToHTML(range);
 
-        var contentRange = document.createRange();
+        var contentRange = scribe.targetWindow.document.createRange();
         contentRange.selectNodeContents(scribe.el);
 
         var serialisedContent = serialiseRangeToHTML(contentRange);

--- a/src/plugins/core/patches/empty-when-deleting.js
+++ b/src/plugins/core/patches/empty-when-deleting.js
@@ -17,7 +17,11 @@ define(function () {
   return function emptyEditorWhenDeleting() {
     return function (scribe) {
 
-      scribe.el.addEventListener('keydown', function handleKeydown(event) {
+      scribe.el.addEventListener('keydown', handleKeydown);
+      scribe.on('deactivated', function() {
+        scribe.el.removeEventListener('keydown', handleKeydown);
+      });
+      function handleKeydown(event) {
         // Delete or backspace
         if (event.keyCode === 8 || event.keyCode === 46) {
           var selection = new scribe.api.Selection();
@@ -43,7 +47,7 @@ define(function () {
             });
           }
         }
-      });
+      }
 
       /**
        * Serialise a range into a HTML string.

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -56,7 +56,7 @@ define(function () {
                 // iterate over it
                 var pElementChildNodes = Array.prototype.slice.call(containerPElement.childNodes);
                 pElementChildNodes.forEach(function(pElementChildNode) {
-                  if (pElementChildNode.nodeName === 'SPAN') {
+                  if (pElementChildNode.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon')) {
                     // Unwrap any SPAN that has been inserted
                     var spanElement = pElementChildNode;
                     new scribe.api.Element(containerPElement).unwrap(spanElement);

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -57,10 +57,10 @@ define(function () {
                 var pElementChildNodes = Array.prototype.slice.call(containerPElement.childNodes);
                 pElementChildNodes.forEach(function(pElementChildNode) {
                   if (pElementChildNode.nodeName === 'SPAN' &&
-                      pElementChildNode.nodeClass != 'font-size-smaller' &&
-                      pElementChildNode.nodeClass != 'font-size-larger' &&
-                      pElementChildNode.nodeClass != 'pplr-icon' &&
-                      pElementChildNode.nodeClass != 'pplr-accent') {
+                      pElementChildNode.className != 'font-size-smaller' &&
+                      pElementChildNode.className != 'font-size-larger' &&
+                      pElementChildNode.className != 'pplr-icon' &&
+                      pElementChildNode.className != 'pplr-accent') {
                     // Unwrap any SPAN that has been inserted
                     var spanElement = pElementChildNode;
                     new scribe.api.Element(containerPElement).unwrap(spanElement);

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -56,7 +56,7 @@ define(function () {
                 // iterate over it
                 var pElementChildNodes = Array.prototype.slice.call(containerPElement.childNodes);
                 pElementChildNodes.forEach(function(pElementChildNode) {
-                  if (pElementChildNode.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon')) {
+                  if (pElementChildNode.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon') && !$(node).hasClass('pplr-accent')) {
                     // Unwrap any SPAN that has been inserted
                     var spanElement = pElementChildNode;
                     new scribe.api.Element(containerPElement).unwrap(spanElement);

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -22,7 +22,7 @@ define(function () {
       //       we know in advance whether there will be a change though?
       // TODO: share somehow with `InsertList` command
       if (scribe.allowsBlockElements()) {
-        scribe.el.addEventListener('keyup', function (event) {
+        var handleKeyup = function (event) {
           if (event.keyCode === 8 || event.keyCode === 46) { // backspace or delete
 
             var selection = new scribe.api.Selection();
@@ -84,6 +84,10 @@ define(function () {
               });
             }
           }
+        };
+        scribe.el.addEventListener('keyup', handleKeyup);
+        scribe.on('deactivated', function() {
+          scribe.el.removeEventListener('keyup', handleKeyup);
         });
       }
     };

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -56,7 +56,7 @@ define(function () {
                 // iterate over it
                 var pElementChildNodes = Array.prototype.slice.call(containerPElement.childNodes);
                 pElementChildNodes.forEach(function(pElementChildNode) {
-                  if (pElementChildNode.nodeName === 'SPAN' && !$(node).hasClass('pplr-icon') && !$(node).hasClass('pplr-accent')) {
+                  if (pElementChildNode.nodeName === 'SPAN' && !$(pElementChildNode).hasClass('pplr-icon') && !$(pElementChildNode).hasClass('pplr-accent')) {
                     // Unwrap any SPAN that has been inserted
                     var spanElement = pElementChildNode;
                     new scribe.api.Element(containerPElement).unwrap(spanElement);

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -56,7 +56,11 @@ define(function () {
                 // iterate over it
                 var pElementChildNodes = Array.prototype.slice.call(containerPElement.childNodes);
                 pElementChildNodes.forEach(function(pElementChildNode) {
-                  if (pElementChildNode.nodeName === 'SPAN' && !$(pElementChildNode).hasClass('pplr-icon') && !$(pElementChildNode).hasClass('pplr-accent')) {
+                  if (pElementChildNode.nodeName === 'SPAN' &&
+                      pElementChildNode.nodeClass != 'font-size-smaller' &&
+                      pElementChildNode.nodeClass != 'font-size-larger' &&
+                      pElementChildNode.nodeClass != 'pplr-icon' &&
+                      pElementChildNode.nodeClass != 'pplr-accent') {
                     // Unwrap any SPAN that has been inserted
                     var spanElement = pElementChildNode;
                     new scribe.api.Element(containerPElement).unwrap(spanElement);

--- a/src/plugins/scribe-plugin-blockquote-command.js
+++ b/src/plugins/scribe-plugin-blockquote-command.js
@@ -36,7 +36,11 @@ define(function () {
        * <enter> keypresses if the caret is on a new line.
        */
       if (scribe.allowsBlockElements()) {
-        scribe.el.addEventListener('keydown', function (event) {
+        scribe.el.addEventListener('keydown', handleKeydown);
+        scribe.on('deactivated', function() {
+          scribe.el.removeEventListener('keydown', handleKeydown);
+        });
+        function handleKeydown(event) {
           if (event.keyCode === 13) { // enter
 
             var command = scribe.getCommand('blockquote');
@@ -48,7 +52,7 @@ define(function () {
               }
             }
           }
-        });
+        }
       }
     };
   };

--- a/src/plugins/scribe-plugin-code-command.js
+++ b/src/plugins/scribe-plugin-code-command.js
@@ -19,7 +19,7 @@ define(function () {
 
           var selectedHtmlDocumentFragment = range.extractContents();
 
-          var codeElement = document.createElement('code');
+          var codeElement = scribe.targetWindow.document.createElement('code');
           codeElement.appendChild(selectedHtmlDocumentFragment);
 
           range.insertNode(codeElement);

--- a/src/plugins/scribe-plugin-curly-quotes.js
+++ b/src/plugins/scribe-plugin-curly-quotes.js
@@ -78,7 +78,7 @@ define(function () {
 
       /** Delete any selected text, insert text instead */
       function replaceSelectedRangeWith(text) {
-        var textNode = document.createTextNode(text);
+        var textNode = scribe.targetWindow.document.createTextNode(text);
 
         var selection = new scribe.api.Selection();
         selection.range.deleteContents();
@@ -88,7 +88,7 @@ define(function () {
       }
 
       function placeCaretAfter(node) {
-        var rangeAfter = document.createRange();
+        var rangeAfter = scribe.targetWindow.document.createRange();
         rangeAfter.setStartAfter(node);
         rangeAfter.setEndAfter(node);
 
@@ -100,7 +100,7 @@ define(function () {
       function substituteCurlyQuotes(html) {
         // We don't want to replace quotes within the HTML markup
         // (e.g. attributes), only to text nodes
-        var holder = document.createElement('div');
+        var holder = scribe.targetWindow.document.createElement('div');
         holder.innerHTML = html;
 
         // Replace straight single and double quotes with curly
@@ -147,7 +147,7 @@ define(function () {
 
       // Apply a function on all text nodes in a container, mutating in place
       function mapTextNodes(container, func) {
-        var walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+        var walker = scribe.targetWindow.document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
         var node = walker.firstChild();
         if (node) {
           do {

--- a/src/plugins/scribe-plugin-curly-quotes.js
+++ b/src/plugins/scribe-plugin-curly-quotes.js
@@ -147,7 +147,7 @@ define(function () {
 
       // Apply a function on all text nodes in a container, mutating in place
       function mapTextNodes(container, func) {
-        var walker = scribe.targetWindow.document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+        var walker = scribe.targetWindow.document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null, false);
         var node = walker.firstChild();
         if (node) {
           do {

--- a/src/plugins/scribe-plugin-curly-quotes.js
+++ b/src/plugins/scribe-plugin-curly-quotes.js
@@ -20,6 +20,9 @@ define(function () {
     return function (scribe) {
       // Substitute quotes while typing
       scribe.el.addEventListener('keypress', input);
+      scribe.on('deactivated', function() {
+        scribe.el.removeEventListener('keypress', input);
+      });
 
       // Substitute quotes on setting content or paste
       scribe.htmlFormatter.formatters.push(substituteCurlyQuotes);

--- a/src/plugins/scribe-plugin-intelligent-unlink-command.js
+++ b/src/plugins/scribe-plugin-intelligent-unlink-command.js
@@ -29,6 +29,17 @@ define(function () {
             }
           }.bind(this));
         } else {
+          // if an A tag has a class, Firefox replaces the A tag with a span with the same class
+          var range, node;
+          range = selection.selection.getRangeAt(0)
+          node = range.commonAncestorContainer;
+          if (node.nodeName === 'A') node.className = null;
+          node = range.startContainer;
+          do {
+            if (node.nodeName === 'A') node.className = null;
+            node = node.nextSibling;
+          } while (node && node != range.endContainer);
+          // end:if an A tag has a class, Firefox replaces the A tag with a span with the same class
           scribe.api.Command.prototype.execute.apply(this, arguments);
         }
       };

--- a/src/plugins/scribe-plugin-keyboard-shortcuts.js
+++ b/src/plugins/scribe-plugin-keyboard-shortcuts.js
@@ -8,7 +8,11 @@ define([
 
   return function (commandsToKeyboardShortcutsMap) {
     return function (scribe) {
-      scribe.el.addEventListener('keydown', function (event) {
+      scribe.el.addEventListener('keydown', handleKeydown);
+      scribe.on('deactivated', function() {
+        scribe.el.removeEventListener('keydown', handleKeydown);
+      });
+      function handleKeydown(event) {
         var commandName = findKey(commandsToKeyboardShortcutsMap, function (isKeyboardShortcut) {
           return isKeyboardShortcut(event);
         });
@@ -24,7 +28,7 @@ define([
             command.execute();
           }
         }
-      });
+      }
     };
   };
 

--- a/src/plugins/scribe-plugin-sanitizer.js
+++ b/src/plugins/scribe-plugin-sanitizer.js
@@ -1,5 +1,5 @@
 define([
-  'html-janitor'
+  'html-janitor-modified'
 ], function (
   HTMLJanitor
 ) {

--- a/src/plugins/scribe-plugin-smart-lists.js
+++ b/src/plugins/scribe-plugin-smart-lists.js
@@ -92,6 +92,9 @@ define(function () {
       }
 
       scribe.el.addEventListener('keypress', input);
+      scribe.on('deactivated', function() {
+        scribe.el.removeEventListener('keypress', input);
+      });
     };
   };
 

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -142,7 +142,7 @@ define([
       }
 
       function getFirstDeepestChild(node) {
-        var treeWalker = this.targetWindow.document.createTreeWalker(node);
+        var treeWalker = this.targetWindow.document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
         var previousNode = treeWalker.currentNode;
         if (treeWalker.firstChild()) {
           // TODO: build list of non-empty elements (used elsewhere)
@@ -201,9 +201,11 @@ define([
     if (! previousUndoItem || (previousUndoItem && this.getContent() !== previousContent)) {
       var selection = new this.api.Selection();
 
-      selection.placeMarkers();
+      if (selection.rangeCount)
+        selection.placeMarkers();
       var html = this.getHTML();
-      selection.removeMarkers();
+      if (selection.rangeCount)
+        selection.removeMarkers();
 
       this.undoManager.push(html);
 

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -271,11 +271,12 @@ define([
 
     var selection = new this.api.Selection();
     var range = selection.range;
-    var div = this.targetWindow.document.createElement('DIV')
-    range.insertNode(div)
-    html = this.htmlFormatter.format(html)
-    div.appendChild(range.createContextualFragment(html))
-    new this.api.Element(div.parentNode).unwrap(div)
+    var div = this.targetWindow.document.createElement('DIV');
+    range.deleteContents();
+    range.insertNode(div);
+    html = this.htmlFormatter.format(html);
+    div.appendChild(range.createContextualFragment(html));
+    new this.api.Element(div.parentNode).unwrap(div);
   };
 
   Scribe.prototype.isDebugModeEnabled = function () {

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -142,7 +142,7 @@ define([
       }
 
       function getFirstDeepestChild(node) {
-        var treeWalker = scribe.targetWindow.document.createTreeWalker(node);
+        var treeWalker = this.targetWindow.document.createTreeWalker(node);
         var previousNode = treeWalker.currentNode;
         if (treeWalker.firstChild()) {
           // TODO: build list of non-empty elements (used elsewhere)

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -35,6 +35,7 @@ define([
       allowBlockElements: true,
       debug: false
     });
+    this.targetWindow = options.targetWindow || window;
     this.commandPatches = {};
     this.plainTextFormatter = new Formatter();
     this.htmlFormatter = new Formatter();
@@ -139,7 +140,7 @@ define([
       }
 
       function getFirstDeepestChild(node) {
-        var treeWalker = document.createTreeWalker(node);
+        var treeWalker = scribe.targetWindow.document.createTreeWalker(node);
         var previousNode = treeWalker.currentNode;
         if (treeWalker.firstChild()) {
           // TODO: build list of non-empty elements (used elsewhere)

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -50,7 +50,7 @@ define([
 
     this.el.setAttribute('contenteditable', true);
 
-    this.el.addEventListener('input', function () {
+    var handleInput = function () {
       /**
        * This event triggers when either the user types something or a native
        * command is executed which causes the content to change (i.e.
@@ -58,7 +58,12 @@ define([
        * these actions, so instead we run the transaction in this event.
        */
       this.transactionManager.run();
-    }.bind(this), false);
+    }.bind(this);
+
+    this.el.addEventListener('input', handleInput, false);
+    this.on('deactivated', function() {
+      this.el.removeEventListener('keypress', handleInput);
+    }.bind(this));
 
     /**
      * Core Plugins
@@ -111,7 +116,7 @@ define([
     }.bind(this);
 
     // TODO: abstract
-    this.el.addEventListener('focus', function placeCaretOnFocus() {
+    var placeCaretOnFocus = function() {
       /**
        * Firefox: Giving focus to a `contenteditable` will place the caret
        * outside of any block elements. Chrome behaves correctly by placing the
@@ -158,8 +163,17 @@ define([
         }
       }
 
+    }.bind(this);
+
+    this.el.addEventListener('focus', placeCaretOnFocus);
+    this.on('deactivated', function() {
+      this.el.removeEventListener('focus', placeCaretOnFocus);
     }.bind(this));
+
     this.el.addEventListener('focus', pushHistoryOnFocus);
+    this.on('deactivated', function() {
+      this.el.removeEventListener('focus', pushHistoryOnFocus);
+    }.bind(this));
   }
 
   Scribe.prototype = Object.create(EventEmitter.prototype);

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -121,6 +121,23 @@ define([
        * We detect when this occurs and fix it by placing the caret ourselves.
        */
       var selection = new this.api.Selection();
+
+      var getFirstDeepestChild = function(node) {
+        var treeWalker = this.targetWindow.document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
+        var previousNode = treeWalker.currentNode;
+        if (treeWalker.firstChild()) {
+          // TODO: build list of non-empty elements (used elsewhere)
+          // Do not include non-empty elements
+          if (treeWalker.currentNode.nodeName === 'BR') {
+            return previousNode;
+          } else {
+            return getFirstDeepestChild(treeWalker.currentNode);
+          }
+        } else {
+          return treeWalker.currentNode;
+        }
+      }.bind(this);
+
       // In Chrome, the range is not created on or before this event loop.
       // It doesn’t matter because this is a fix for Firefox.
       if (selection.range) {
@@ -141,21 +158,6 @@ define([
         }
       }
 
-      function getFirstDeepestChild(node) {
-        var treeWalker = this.targetWindow.document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
-        var previousNode = treeWalker.currentNode;
-        if (treeWalker.firstChild()) {
-          // TODO: build list of non-empty elements (used elsewhere)
-          // Do not include non-empty elements
-          if (treeWalker.currentNode.nodeName === 'BR') {
-            return previousNode;
-          } else {
-            return getFirstDeepestChild(treeWalker.currentNode);
-          }
-        } else {
-          return treeWalker.currentNode;
-        }
-      }
     }.bind(this));
     this.el.addEventListener('focus', pushHistoryOnFocus);
   }

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -268,7 +268,14 @@ define([
   Scribe.prototype.insertHTML = function (html) {
     // TODO: error if the selection is not within the Scribe instance? Or
     // focus the Scribe instance if it is not already focused?
-    this.getCommand('insertHTML').execute(this.htmlFormatter.format(html));
+
+    var selection = new this.api.Selection();
+    var range = selection.range;
+    var div = this.targetWindow.document.createElement('DIV')
+    range.insertNode(div)
+    html = this.htmlFormatter.format(html)
+    div.appendChild(range.createContextualFragment(html))
+    new this.api.Element(div.parentNode).unwrap(div)
   };
 
   Scribe.prototype.isDebugModeEnabled = function () {

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -230,7 +230,7 @@ after(function () {
 
 beforeEach(function () {
   return driver.wait(function () {
-    return driver.executeScript('return document.readyState').then(function (returnValue) {
+    return driver.executeScript('return scribe.targetWindow.document.readyState').then(function (returnValue) {
       return returnValue === 'complete';
     });
   });
@@ -261,7 +261,7 @@ describe('undo manager', function () {
             // Insert a marker so we can see where the caret is
             var selection = window.getSelection();
             var range = selection.getRangeAt(0);
-            var marker = document.createElement('em');
+            var marker = scribe.targetWindow.document.createElement('em');
             marker.classList.add('scribe-marker');
             range.insertNode(marker);
           }).then(function () {
@@ -1430,7 +1430,7 @@ describe('patches', function () {
 
         beforeEach(function () {
           return driver.executeScript(function () {
-            document.body.style.lineHeight = 2;
+            scribe.targetWindow.document.body.style.lineHeight = 2;
           });
         });
 
@@ -1504,7 +1504,7 @@ describe('patches', function () {
 
       beforeEach(function () {
         return driver.executeScript(function () {
-          document.body.style.lineHeight = 2;
+          scribe.targetWindow.document.body.style.lineHeight = 2;
         });
       });
 
@@ -1624,7 +1624,7 @@ describe('patches', function () {
 
       beforeEach(function () {
         return driver.executeScript(function () {
-          document.body.style.lineHeight = 2;
+          scribe.targetWindow.document.body.style.lineHeight = 2;
         });
       });
 


### PR DESCRIPTION
We've made these changes to support our use of Scribe in the [Populr](https://populr.me) editor.

There are a few places where we hard-coded some class names into the span checks, which is a hack to support our specific use case that shouldn't be merged (search for pplr to see what I mean).

All changes are intended to be cross-browser compatible (no browser specific hacks). It has been tested in IE11, and we intend for it to work in IE10.

Anonymous functions were replaced with named functions for event listeners so that they could be removed upon Scribe deactivation. (We were running in a situation in which Scribe was deactivated and reactivated on a particular element, after which "paste" would paste in multiple copies.)

I didn't add any test cases, so I understand that this doesn't meet your requirements for a pull request, but I thought maybe it would be useful to share with you even if it doesn't actually get merged.