### PR TITLE
gh-pages: Fix "strikethrough" button

### DIFF
--- a/example.js
+++ b/example.js
@@ -88,7 +88,7 @@ require({
       b: {},
       strong: {},
       i: {},
-      s: {},
+      strike: {},
       blockquote: {},
       ol: {},
       ul: {},


### PR DESCRIPTION
Allow `<strike>` HTML tags in the gh-pages example editor (side thought... why doesn't that command insert a `<del>` tag instead?)

Fixes the "StrikeThrough" button from not doing anything.
