### PR TITLE
Cleaner plugin loading

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,24 +1,12 @@
-define([
-  './api/command-patch',
-  './api/command',
-  './api/node',
-  './api/selection',
-  './api/simple-command'
-], function (
-  buildCommandPatch,
-  buildCommand,
-  Node,
-  buildSelection,
-  buildSimpleCommand
-) {
+define(function (require) {
 
   'use strict';
 
   return function Api(scribe) {
-    this.CommandPatch = buildCommandPatch(scribe);
-    this.Command = buildCommand(scribe);
-    this.Node = Node;
-    this.Selection = buildSelection(scribe);
-    this.SimpleCommand = buildSimpleCommand(this, scribe);
+    this.CommandPatch = require('./api/command-patch')(scribe);
+    this.Command = require('./api/command')(scribe);
+    this.Node = require('./api/node');
+    this.Selection = require('./api/selection')(scribe);
+    this.SimpleCommand = require('./api/simple-command')(this, scribe);
   };
 });

--- a/src/plugins/core/commands.js
+++ b/src/plugins/core/commands.js
@@ -1,31 +1,15 @@
-define([
-  './commands/indent',
-  './commands/insert-list',
-  './commands/outdent',
-  './commands/redo',
-  './commands/subscript',
-  './commands/superscript',
-  './commands/undo'
-], function (
-  indent,
-  insertList,
-  outdent,
-  redo,
-  subscript,
-  superscript,
-  undo
-) {
+define(function (require) {
 
   'use strict';
 
   return {
-    indent: indent,
-    insertList: insertList,
-    outdent: outdent,
-    redo: redo,
-    subscript: subscript,
-    superscript: superscript,
-    undo: undo
+    indent: require('./commands/indent'),
+    insertList: require('./commands/insert-list'),
+    outdent: require('./commands/outdent'),
+    redo: require('./commands/redo'),
+    subscript: require('./commands/subscript'),
+    superscript: require('./commands/superscript'),
+    undo: require('./commands/undo')
   };
 
 });

--- a/src/plugins/core/patches.js
+++ b/src/plugins/core/patches.js
@@ -1,20 +1,4 @@
-define([
-  './patches/commands/bold',
-  './patches/commands/indent',
-  './patches/commands/insert-html',
-  './patches/commands/insert-list',
-  './patches/commands/outdent',
-  './patches/commands/create-link',
-  './patches/events'
-], function (
-  boldCommand,
-  indentCommand,
-  insertHTMLCommand,
-  insertListCommands,
-  outdentCommand,
-  createLinkCommand,
-  events
-) {
+define(function (require) {
 
   /**
    * Command patches browser inconsistencies. They do not perform core features
@@ -26,14 +10,14 @@ define([
 
   return {
     commands: {
-      bold: boldCommand,
-      indent: indentCommand,
-      insertHTML: insertHTMLCommand,
-      insertList: insertListCommands,
-      outdent: outdentCommand,
-      createLink: createLinkCommand,
+      bold: require('./patches/commands/bold'),
+      indent: require('./patches/commands/indent'),
+      insertHTML: require('./patches/commands/insert-html'),
+      insertList: require('./patches/commands/insert-list'),
+      outdent: require('./patches/commands/outdent'),
+      createLink: require('./patches/commands/create-link'),
     },
-    events: events
+    events: require('./patches/events')
   };
 
 });


### PR DESCRIPTION
When I creating new patch I realized that I needed to define it in 3-4 different spots. Now that is a a lot to keep track of. First commit changes the requires to use style suggested by #185. 

<del>Second commit extends extends the `.use` method. It can now accept an Object and it will bind it magically. I also made sure that it can accept two different types of objects. like:

``` Javascript
var simple = {bold: function(scribe) { }}
var nested = {bold: function() {
    return function (scribe) {  }
}}
```

This means that adding a plugin or patch is **only one line**. If you think this is a good idea I am happy to add documentation, API and tests. </del>
