### PR TITLE
Issues with command state/value overrides 

### DIFF
--- a/src/api/command-patch.js
+++ b/src/api/command-patch.js
@@ -8,9 +8,13 @@ define(function () {
     }
 
     CommandPatch.prototype.execute = function (value) {
-      scribe.transactionManager.run(function () {
+      if (scribe.selection === undefined) {
         document.execCommand(this.commandName, false, value || null);
-      }.bind(this));
+      } else {
+        scribe.transactionManager.run(function () {
+          document.execCommand(this.commandName, false, value || null);
+        }.bind(this));
+      }
     };
 
     CommandPatch.prototype.queryState = function () {

--- a/src/api/command-patch.js
+++ b/src/api/command-patch.js
@@ -8,7 +8,8 @@ define(function () {
     }
 
     CommandPatch.prototype.execute = function (value) {
-      if (scribe.selection === undefined) {
+      var selection = new scribe.api.Selection().selection;
+      if (selection === undefined || selection.type === 'Caret') {
         document.execCommand(this.commandName, false, value || null);
       } else {
         scribe.transactionManager.run(function () {

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -32,7 +32,6 @@ describe('commands', function () {
       when('the command is executed', function () {
         beforeEach(function () {
           scribeNode.click();
-
           return executeCommand('bold');
         });
 
@@ -44,6 +43,26 @@ describe('commands', function () {
           it('should insert the typed characters inside of a B element, inside of a P element', function () {
             return scribeNode.getInnerHTML().then(function (innerHTML) {
               expect(innerHTML).to.have.html('<p><b>1</b><firefox-bogus-br></p>');
+            });
+          });
+        });
+      });
+    });
+
+    givenContentOf('<p>testing&nbsp;</p>', function () {
+      when('the command is executed', function () {
+        beforeEach(function () {
+          return executeCommand('bold');
+        });
+
+        when('the user types', function () {
+          beforeEach(function () {
+            return scribeNode.sendKeys('2');
+          });
+
+          it('should insert the typed characters inside of a B element, inside of a P element', function () {
+            return scribeNode.getInnerHTML().then(function (innerHTML) {
+              expect(innerHTML).to.have.html('<p><b>2</b>testing&nbsp;</p>');
             });
           });
         });

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -49,7 +49,7 @@ describe('commands', function () {
       });
     });
 
-    givenContentOf('<p>testing&nbsp;</p>', function () {
+    givenContentOf('<p>1&nbsp;</p>', function () {
       when('the command is executed', function () {
         beforeEach(function () {
           return executeCommand('bold');
@@ -62,7 +62,7 @@ describe('commands', function () {
 
           it('should insert the typed characters inside of a B element, inside of a P element', function () {
             return scribeNode.getInnerHTML().then(function (innerHTML) {
-              expect(innerHTML).to.have.html('<p><b>2</b>testing&nbsp;</p>');
+              expect(innerHTML).to.have.html('<p><b>2</b>1&nbsp;</p>');
             });
           });
         });


### PR DESCRIPTION
So, I've noticed that in the example editor, hitting bold, italic, etc before typing doesn't always work as expected.

If you type a few non-space characters, and hit command-B, the *next* character you type will be bold. However, if you type a space character (translated to an `&nbsp;`), and hit command-B, it appears that nothing happens.

After some investigation, I believe that scribe is inadvertently causing the [contenteditable state/value](https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#state-override) overrides to get reset, probably while running formatters.

I've written a small test to demonstrate this, and have temporarily patched the issue in command-patch.js, by just not running the transaction manager on an empty selection. Perhaps there's a better place to make this change? Would love some feedback on this.