### PR TITLE
Fixes #204 and #153.

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -12,6 +12,7 @@ define(function () {
     }
 
     Selection.prototype.getContaining = function (nodeFilter) {
+      if (!this.range) return;
       var node = new scribe.api.Node(this.range.commonAncestorContainer);
       var isTopContainerElement = node.node && node.node.attributes
          && node.node.attributes.getNamedItem('contenteditable');
@@ -20,6 +21,8 @@ define(function () {
     };
 
     Selection.prototype.placeMarkers = function () {
+      if (!this.range) return;
+      if (!scribe.el.contains(this.range.commonAncestorContainer)) return;
       var startMarker = document.createElement('em');
       startMarker.classList.add('scribe-marker');
       var endMarker = document.createElement('em');


### PR DESCRIPTION
Makes sure ```this.range``` is defined when calling ```selection.getContaining``` and ```selection.placeMarkers```. Also makes sure the current selection is inside the scribe element before placing markers. Fixes #204 and #153.