### PR TITLE
Partial fixes for IE11 compatibility

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -55,7 +55,7 @@ define([
         }
 
         function getFirstDeepestChild(node) {
-          var treeWalker = document.createTreeWalker(node);
+          var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
           var previousNode = treeWalker.currentNode;
           if (treeWalker.firstChild()) {
             // TODO: build list of non-empty elements (used elsewhere)

--- a/src/plugins/core/formatters/html/enforce-p-elements.js
+++ b/src/plugins/core/formatters/html/enforce-p-elements.js
@@ -67,7 +67,7 @@ define([
 
   // Traverse the tree, wrapping child nodes as we go.
   function traverse(parentNode) {
-    var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
+    var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
     var node = treeWalker.firstChild();
 
     // FIXME: does this recurse down?

--- a/src/plugins/core/inline-elements-mode.js
+++ b/src/plugins/core/inline-elements-mode.js
@@ -4,7 +4,7 @@ define(function () {
 
   // TODO: abstract
   function hasContent(rootNode) {
-    var treeWalker = document.createTreeWalker(rootNode);
+    var treeWalker = document.createTreeWalker(rootNode, NodeFilter.SHOW_ALL, null, false);
 
     while (treeWalker.nextNode()) {
       if (treeWalker.currentNode) {

--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -25,7 +25,7 @@ define(['scribe-common/src/element'], function (element) {
           sanitize(scribe.el);
 
           function sanitize(parentNode) {
-            var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
+            var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
             var node = treeWalker.firstChild();
             if (!node) { return; }
 


### PR DESCRIPTION
Adds the parameters required in IE to `document.createTreeWalker` for the following files: 

```
src/plugins/core/events.js
src/plugins/core/formatters/html/enforce-p-elements.js
src/plugins/core/inline-elements-mode.js
src/plugins/core/patches/commands/insert-html.js
```

These changes are covered by #218 and/or other of @daniel-nelson's pull requests, but since they seem to be mixed up with unrelated changes, I've decided to prepare this pull request for the some of the more straightforward issues so that they can be easily merged, and so we may be able to / can begin fixing each of IE's problems one by one.
