### PR TITLE
Do not insert BR in empty inline elements when parent node contains text

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "scribe",
   "dependencies": {
     "lodash-amd": "2.4.1",
-    "scribe-common": "0.0.7"
+    "scribe-common": "0.0.11"
   },
   "devDependencies": {
     "requirejs": "~2.1.9",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/scribe.js",
   "dependencies": {
     "lodash-amd": "~2.4.1",
-    "scribe-common": "~0.0.7"
+    "scribe-common": "~0.0.11"
   },
   "devDependencies": {
     "chai": "~1.9.1",

--- a/src/plugins/core/formatters/html/ensure-selectable-containers.js
+++ b/src/plugins/core/formatters/html/ensure-selectable-containers.js
@@ -18,7 +18,11 @@ define([
   var html5VoidElements = ['AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT', 'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR'];
 
   function parentHasNoTextContent(node) {
-    return node.parentNode.textContent.trim() === '';
+    if (element.isCaretPositionNode(node)) {
+      return true;
+    } else {
+      return node.parentNode.textContent.trim() === '';
+    }
   }
 
 
@@ -30,13 +34,13 @@ define([
 
     function isEmpty(node) {
 
-      if ((node.children.length === 0 && !element.isAllowedEmptyElement(node))
+      if ((node.children.length === 0 && element.isBlockElement(node))
         || (node.children.length === 1 && element.isSelectionMarkerNode(node.children[0]))) {
          return true;
       }
 
-      // Do not insert BR in empty inline elements with parent containing text
-      if (element.isAllowedEmptyElement(node) && node.children.length === 0) {
+      // Do not insert BR in empty non block elements with parent containing text
+      if (!element.isBlockElement(node) && node.children.length === 0) {
         return parentHasNoTextContent(node);
       }
 


### PR DESCRIPTION
This solves the bug shown in the gif...
![bold_space_bug](https://cloud.githubusercontent.com/assets/5630563/4476796/cfeb79be-4978-11e4-926d-6d06e9eeecc4.gif)

and the fix....
![bold_space_fix](https://cloud.githubusercontent.com/assets/5630563/4476805/e6011a88-4978-11e4-9227-946fc5a7397b.gif)
