### PR TITLE
Fix for the range positioning in FF

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -45,9 +45,8 @@ define([
           var focusElement = getFirstDeepestChild(scribe.el.firstChild);
 
           var range = selection.range;
-
-          range.setStart(focusElement, 0);
-          range.setEnd(focusElement, 0);
+          range.setStart(focusElement, range.startOffset);
+          range.setEnd(focusElement, range.endOffset);
 
           selection.selection.removeAllRanges();
           selection.selection.addRange(range);


### PR DESCRIPTION
This fixes the range poisitioning in FF that the the new focus introduced. Chrome sometimes set the range and sometimes doesn't - will add this to the BROWSERINCONSISTENCIES file along with tests etc.

\cc @theefer 
