### PR TITLE
Add information on running tests to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ internal CMS’ rich text editor.
 It is likely that there will be unknown edge cases, but these will be addressed
 when they are discovered.
 
+### How do I run tests?
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for information about running tests.
+
 ### Why does Scribe have a custom undo manager?
 
 The [native API for formatting content in a


### PR DESCRIPTION
If you read the README, there's nothing that makes it obvious that the information you need to run tests locally is in CONTRIBUTING.md.

This changeset resolves that issue.
