### PR TITLE
Updates list of block level elements

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -2,10 +2,11 @@ define(['lodash-amd/modern/collections/contains'], function (contains) {
 
   'use strict';
 
-  // TODO: not exhaustive?
-  var blockElementNames = ['P', 'LI', 'DIV', 'BLOCKQUOTE', 'UL', 'OL', 'H1',
-                           'H2', 'H3', 'H4', 'H5', 'H6', 'TABLE', 'TH', 'TD',
-                           'ASIDE', 'HR'];
+  var blockElementNames = ['ADDRESS', 'ARTICLE', 'ASIDE', 'AUDIO', 'BLOCKQUOTE', 'CANVAS', 'DD',
+                           'DIV', 'FIELDSET', 'FIGCAPTION', 'FIGURE', 'FOOTER', 'FORM', 'H1',
+                           'H2', 'H3', 'H4', 'H5', 'H6', 'HEADER', 'HGROUP', 'HR', 'LI',
+                           'NOSCRIPT', 'OL', 'OUTPUT', 'P', 'PRE', 'SECTION', 'TABLE', 'TD',
+                           'TH', 'TFOOT', 'UL', 'VIDEO'];
   function isBlockElement(node) {
     return contains(blockElementNames, node.nodeName);
   }


### PR DESCRIPTION
We regularly use ASIDE and HR in our editor. This change prevents Scribe's formatters from adding extra paragraphs when these elements are present.
