### PR TITLE
CI: Travis: Use caches for NPM and Bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ node_js:
 
 sudo: false
 
+cache:
+  directories:
+    - node_modules
+    - bower_components
+
 addons:
   sauce_connect: true
 


### PR DESCRIPTION
While the bulk of the time in the build in the SauceLabs testing there is no need to download a complete environment every time.

If this works for Scribe then I'm planning to add the config directly to the plugin projects.
