### PR TITLE
Fixes missing dependency in the AMD example

### DIFF
--- a/examples/amd.html
+++ b/examples/amd.html
@@ -38,7 +38,8 @@ require({
   paths: {
     'scribe-common': '../bower_components/scribe-common',
     'lodash-amd': '../bower_components/lodash-amd',
-    'html-janitor':  '../bower_components/html-janitor/html-janitor'
+    'html-janitor':  '../bower_components/html-janitor/html-janitor',
+    'immutable': '../bower_components/immutable'
   }
 }, [
   '../src/scribe',


### PR DESCRIPTION
The AMD example fails to load because the immutable library is not configured for requireJS.
