### PR TITLE
Refactored require paths for plugin compatibility

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -15,7 +15,7 @@ define([
   './event-emitter',
   './element',
   './node',
-  'immutable/dist/immutable'
+  'bower_components/immutable/dist/immutable'
 ], function (
   defaults,
   commands,

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -8,11 +8,11 @@
     <script src="../../bower_components/requirejs/require.js"></script>
     <script>
       require.config({
+        baseUrl: '../../',
         paths: {
           'scribe-common': '../../bower_components/scribe-common',
           'lodash-amd': '../../bower_components/lodash-amd',
-          'html-janitor':  '../../bower_components/html-janitor/html-janitor',
-          'immutable': '../../bower_components/immutable'
+          'html-janitor':  '../../bower_components/html-janitor/html-janitor'
         }
       });
     </script>


### PR DESCRIPTION
As mentioned within https://github.com/guardian/scribe/issues/311 requiring immutable.js with:

`'immutable/dist/immutable'` 

breaks the https://github.com/guardian/scribe-plugin-noting test suite. I've re-jigged the require paths so that this should no longer be a problem.  As I don't work with other plugins would be good to know that this doesn't break anything else @robinedman @theefer @rrees? Test suite run's fine on my local.