### PR TITLE
Add support for paste formatters

### DIFF
--- a/examples/example-paste-formatter.js
+++ b/examples/example-paste-formatter.js
@@ -1,0 +1,25 @@
+/**
+ * This is a simple paste formatter example which
+ * removes style attributes from all elements that have
+ * them.
+ */
+define(function () {
+
+  'use strict';
+
+  return function () {
+    return function (scribe) {
+
+      scribe.registerHTMLFormatter('paste', function (html) {
+        var bin = document.createElement('div');
+        bin.innerHTML = html;
+        var styledEls = bin.querySelectorAll('[style]');
+        Array.prototype.forEach.call(styledEls, function (el) {
+          el.removeAttribute('style');
+        });
+        return bin.innerHTML;
+      });
+    };
+  };
+
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "q": "~1.0.0",
     "request": "~2.33.0",
     "selenium-webdriver": "~2.41.0",
-    "scribe-test-harness": "~0.0.7"
+    "scribe-test-harness": "~0.0.14"
   },
   "scripts": {
     "test": "./run-tests.sh"

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -218,8 +218,9 @@ define([
           event.preventDefault();
 
           if (contains(event.clipboardData.types, 'text/html')) {
-
-            scribe.insertHTML(event.clipboardData.getData('text/html'));
+            var html = event.clipboardData.getData('text/html');
+            html = scribe._htmlFormatterFactory.formatPaste(html);
+            scribe.insertHTML(html);
           } else {
             scribe.insertPlainText(event.clipboardData.getData('text/plain'));
           }
@@ -265,6 +266,7 @@ define([
              */
             scribe.el.focus();
 
+            data = scribe._htmlFormatterFactory.formatPaste(data);
             scribe.insertHTML(data);
           }, 1);
         }

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -279,7 +279,8 @@ define([
       sanitize: Immutable.List(),
       // Normalize content to ensure it is ready for interaction
       normalize: Immutable.List(),
-      'export': Immutable.List()
+      paste: [],
+      export: []
     };
   }
 
@@ -294,6 +295,12 @@ define([
     }, html);
 
     return formatted;
+  };
+
+  HTMLFormatterFactory.prototype.formatPaste = function (html) {
+    return this.formatters.paste.reduce(function (formattedData, formatter) {
+      return formatter(formattedData);
+    }, html);
   };
 
   HTMLFormatterFactory.prototype.formatForExport = function (html) {

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -279,8 +279,8 @@ define([
       sanitize: Immutable.List(),
       // Normalize content to ensure it is ready for interaction
       normalize: Immutable.List(),
-      paste: [],
-      export: []
+      paste: Immutable.List(),
+      'export': Immutable.List()
     };
   }
 

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -12,7 +12,8 @@
           'scribe-common': '../../bower_components/scribe-common',
           'lodash-amd': '../../bower_components/lodash-amd',
           'html-janitor':  '../../bower_components/html-janitor/html-janitor',
-          'immutable': '../../bower_components/immutable'
+          'immutable': '../../bower_components/immutable',
+          'example-paste-formatter': '../../examples/example-paste-formatter'
         }
       });
     </script>

--- a/test/paste-formatters.spec.js
+++ b/test/paste-formatters.spec.js
@@ -1,0 +1,39 @@
+var chai = require('chai');
+var expect = chai.expect;
+
+var helpers = require('scribe-test-harness/helpers');
+helpers.registerChai(chai);
+var whenPastingHTMLOf = helpers.whenPastingHTMLOf;
+var initializeScribe = helpers.initializeScribe.bind(null, '../../src/scribe');
+
+var initializeExamplePasteFormatter = function () {
+  function setupFormatter(done) {
+    require(['example-paste-formatter'], function (ExamplePasteFormatter) {
+      'use strict';
+      window.scribe.use(ExamplePasteFormatter());
+      done();
+    });
+  }
+  return helpers.driver.executeAsyncScript(setupFormatter);
+};
+
+describe('paste formatters', function () {
+
+  beforeEach(function () {
+    return initializeScribe().then(function () {
+      return initializeExamplePasteFormatter();
+    });
+  });
+
+  describe('example paste formatter', function() {
+    whenPastingHTMLOf('<p style="font-family:Comic Sans">1</p><p style="font-style:microsoft-word-junk">2</p>', function () {
+      it('should strip the style attributes', function () {
+        // Chrome and Firefox: '<p>1</p><p>\n</p><p>2</p>'
+        return helpers.scribeNode.getInnerHTML().then(function (innerHTML) {
+          expect(innerHTML).to.have.html('<p>1</p><p>2</p>');
+        });
+      });
+    });
+  });
+
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -22,6 +22,7 @@ mocha.reporter('spec');
 mocha.addFile(__dirname + '/block-mode.spec.js');
 mocha.addFile(__dirname + '/commands.spec.js');
 mocha.addFile(__dirname + '/formatters.spec.js');
+mocha.addFile(__dirname + '/paste-formatters.spec.js');
 mocha.addFile(__dirname + '/inline-elements-mode.spec.js');
 mocha.addFile(__dirname + '/patches.spec.js');
 mocha.addFile(__dirname + '/undo-manager.spec.js');


### PR DESCRIPTION
This is all @awentzonline's work (thank you!!), just with the addition of a test. This should resolve #241 if all looks good.  It depends on https://github.com/guardian/scribe-test-harness/pull/10 being merged and released as it needs a new helper method for inserting via paste (if it's simpler, I could instead inline that for now).

Because the example paste formatter used for the test is kind of a one-off, I wasn't totally sure where to put it -- it lives in "examples" for now.