### PR TITLE
Patched event emitter so multiple event assignment is imposible

### DIFF
--- a/src/event-emitter.js
+++ b/src/event-emitter.js
@@ -1,4 +1,4 @@
-define(['lodash-amd/modern/arrays/pull'], function (pull) {
+define(['lodash-amd/modern/arrays/pull', 'immutable/dist/immutable'], function (pull, Immutable) {
 
   'use strict';
 
@@ -10,30 +10,21 @@ define(['lodash-amd/modern/arrays/pull'], function (pull) {
   }
 
   EventEmitter.prototype.on = function (eventName, fn) {
-    var listeners = this._listeners[eventName] || [];
-
-    listeners.forEach(function(listener){
-      if(listener === fn){
-        return;
-      }
-    });
-
-    listeners.push(fn);
-
-    this._listeners[eventName] = listeners;
+    var listeners = this._listeners[eventName] || new Immutable.Set();
+    this._listeners[eventName] = listeners.add(fn);
   };
 
   EventEmitter.prototype.off = function (eventName, fn) {
-    var listeners = this._listeners[eventName] || [];
+    this._listeners[eventName] = (this._listeners[eventName] || new Immutable.Set());
     if (fn) {
-      pull(listeners, fn);
+      this._listeners = this._listeners.delete(fn);
     } else {
       delete this._listeners[eventName];
     }
   };
 
   EventEmitter.prototype.trigger = function (eventName, args) {
-    var listeners = this._listeners[eventName] || [];
+    var listeners = this._listeners[eventName] || new Immutable.Set();
 
     listeners.forEach(function (listener) {
       listener.apply(null, args);

--- a/src/event-emitter.js
+++ b/src/event-emitter.js
@@ -12,6 +12,12 @@ define(['lodash-amd/modern/arrays/pull'], function (pull) {
   EventEmitter.prototype.on = function (eventName, fn) {
     var listeners = this._listeners[eventName] || [];
 
+    listeners.forEach(function(listener){
+      if(listener === fn){
+        return;
+      }
+    });
+
     listeners.push(fn);
 
     this._listeners[eventName] = listeners;


### PR DESCRIPTION
Currently there is no check to see if an function has already been assigned to a particular event within `src/event-emitter.js`.  This causes problems within the noting plugin. Specifically when media is added to Composer as more scribe instances are created and thus event handlers are assigned multiple times, see: https://github.com/guardian/scribe-plugin-noting/issues/75.

This PR ensures event handlers can only be assigned to a particular event once.