### PR TITLE
Added selection detection to place markers

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -37,96 +37,24 @@ function (elementHelper) {
 
       var scribeNodeRange = document.createRange();
       scribeNodeRange.selectNodeContents(scribe.el);
-      //check if the END of the current selection is within the scribe node
-      if (scribeNodeRange.compareBoundaryPoints(Range.START_TO_END, this.range) < 0){
-        return;
-      }
 
-      var startMarker = document.createElement('em');
-      startMarker.classList.add('scribe-marker');
-      var endMarker = document.createElement('em');
-      endMarker.classList.add('scribe-marker');
+      //we want to ensure that the current selection is within the current scribe node
+      //if this isn't true scribe will place markers within the selections parent
+      //we want to ensure that scribe ONLY places markers within it's own element
+      var selectionStartWithinScribeElementStart = this.range.compareBoundaryPoints(Range.START_TO_START, scribeNodeRange) >= 0;
+      var selectionEndWithinScribeElementEnd = this.range.compareBoundaryPoints(Range.END_TO_END, scribeNodeRange) <= 0;
 
-      // End marker
-      var rangeEnd = this.range.cloneRange();
-      rangeEnd.collapse(false);
-      rangeEnd.insertNode(endMarker);
+      if (selectionStartWithinScribeElementStart && selectionEndWithinScribeElementEnd){
 
-      /**
-       * Chrome and Firefox: `Range.insertNode` inserts a bogus text node after
-       * the inserted element. We just remove it. This in turn creates several
-       * bugs when perfoming commands on selections that contain an empty text
-       * node (`removeFormat`, `unlink`).
-       * As per: http://jsbin.com/hajim/5/edit?js,console,output
-       */
-      // TODO: abstract into polyfill for `Range.insertNode`
-      if (endMarker.nextSibling &&
-          endMarker.nextSibling.nodeType === Node.TEXT_NODE
-          && endMarker.nextSibling.data === '') {
-        endMarker.parentNode.removeChild(endMarker.nextSibling);
-      }
+        var startMarker = document.createElement('em');
+        startMarker.classList.add('scribe-marker');
+        var endMarker = document.createElement('em');
+        endMarker.classList.add('scribe-marker');
 
-
-
-      /**
-       * Chrome and Firefox: `Range.insertNode` inserts a bogus text node before
-       * the inserted element when the child element is at the start of a block
-       * element. We just remove it.
-       * FIXME: Document why we need to remove this
-       * As per: http://jsbin.com/sifez/1/edit?js,console,output
-       */
-      if (endMarker.previousSibling &&
-          endMarker.previousSibling.nodeType === Node.TEXT_NODE
-          && endMarker.previousSibling.data === '') {
-        endMarker.parentNode.removeChild(endMarker.previousSibling);
-      }
-
-
-      /**
-       * This is meant to test Chrome inserting erroneous text blocks into
-       * the scribe el when focus switches from a scribe.el to a button to
-       * the scribe.el. However, this is impossible to simlulate correctly
-       * in a test.
-       *
-       * This behaviour does not happen in Firefox.
-       *
-       * See http://jsbin.com/quhin/2/edit?js,output,console
-       *
-       * To reproduce the bug, follow the following steps:
-       *    1. Select text and create H2
-       *    2. Move cursor to front of text.
-       *    3. Remove the H2 by clicking the button
-       *    4. Observe that you are left with an empty H2
-       *        after the element.
-       *
-       * The problem is caused by the Range being different, depending on
-       * the position of the marker.
-       *
-       * Consider the following two scenarios.
-       *
-       * A)
-       *   1. scribe.el contains: ["1", <em>scribe-marker</em>]
-       *   2. Click button and click the right of to scribe.el
-       *   3. scribe.el contains: ["1", <em>scribe-marker</em>. #text]
-       *
-       *   This is wrong but does not cause the problem.
-       *
-       * B)
-       *   1. scribe.el contains: ["1", <em>scribe-marker</em>]
-       *   2. Click button and click to left of scribe.el
-       *   3. scribe.el contains: [#text, <em>scribe-marker</em>, "1"]
-       *
-       * The second example sets the range in the wrong place, meaning
-       * that in the second case the formatBlock is executed on the wrong
-       * element [the text node] leaving the empty H2 behind.
-       **/
-
-
-      if (! this.selection.isCollapsed) {
-        // Start marker
-        var rangeStart = this.range.cloneRange();
-        rangeStart.collapse(true);
-        rangeStart.insertNode(startMarker);
+        // End marker
+        var rangeEnd = this.range.cloneRange();
+        rangeEnd.collapse(false);
+        rangeEnd.insertNode(endMarker);
 
         /**
          * Chrome and Firefox: `Range.insertNode` inserts a bogus text node after
@@ -136,29 +64,106 @@ function (elementHelper) {
          * As per: http://jsbin.com/hajim/5/edit?js,console,output
          */
         // TODO: abstract into polyfill for `Range.insertNode`
-        if (startMarker.nextSibling &&
-            startMarker.nextSibling.nodeType === Node.TEXT_NODE
-            && startMarker.nextSibling.data === '') {
-          startMarker.parentNode.removeChild(startMarker.nextSibling);
+        if (endMarker.nextSibling &&
+            endMarker.nextSibling.nodeType === Node.TEXT_NODE
+            && endMarker.nextSibling.data === '') {
+          endMarker.parentNode.removeChild(endMarker.nextSibling);
         }
 
+
+
         /**
-         * Chrome and Firefox: `Range.insertNode` inserts a bogus text node
-         * before the inserted element when the child element is at the start of
-         * a block element. We just remove it.
+         * Chrome and Firefox: `Range.insertNode` inserts a bogus text node before
+         * the inserted element when the child element is at the start of a block
+         * element. We just remove it.
          * FIXME: Document why we need to remove this
          * As per: http://jsbin.com/sifez/1/edit?js,console,output
          */
-        if (startMarker.previousSibling &&
-            startMarker.previousSibling.nodeType === Node.TEXT_NODE
-            && startMarker.previousSibling.data === '') {
-          startMarker.parentNode.removeChild(startMarker.previousSibling);
+        if (endMarker.previousSibling &&
+            endMarker.previousSibling.nodeType === Node.TEXT_NODE
+            && endMarker.previousSibling.data === '') {
+          endMarker.parentNode.removeChild(endMarker.previousSibling);
         }
+
+
+        /**
+         * This is meant to test Chrome inserting erroneous text blocks into
+         * the scribe el when focus switches from a scribe.el to a button to
+         * the scribe.el. However, this is impossible to simlulate correctly
+         * in a test.
+         *
+         * This behaviour does not happen in Firefox.
+         *
+         * See http://jsbin.com/quhin/2/edit?js,output,console
+         *
+         * To reproduce the bug, follow the following steps:
+         *    1. Select text and create H2
+         *    2. Move cursor to front of text.
+         *    3. Remove the H2 by clicking the button
+         *    4. Observe that you are left with an empty H2
+         *        after the element.
+         *
+         * The problem is caused by the Range being different, depending on
+         * the position of the marker.
+         *
+         * Consider the following two scenarios.
+         *
+         * A)
+         *   1. scribe.el contains: ["1", <em>scribe-marker</em>]
+         *   2. Click button and click the right of to scribe.el
+         *   3. scribe.el contains: ["1", <em>scribe-marker</em>. #text]
+         *
+         *   This is wrong but does not cause the problem.
+         *
+         * B)
+         *   1. scribe.el contains: ["1", <em>scribe-marker</em>]
+         *   2. Click button and click to left of scribe.el
+         *   3. scribe.el contains: [#text, <em>scribe-marker</em>, "1"]
+         *
+         * The second example sets the range in the wrong place, meaning
+         * that in the second case the formatBlock is executed on the wrong
+         * element [the text node] leaving the empty H2 behind.
+         **/
+
+
+        if (! this.selection.isCollapsed) {
+          // Start marker
+          var rangeStart = this.range.cloneRange();
+          rangeStart.collapse(true);
+          rangeStart.insertNode(startMarker);
+
+          /**
+           * Chrome and Firefox: `Range.insertNode` inserts a bogus text node after
+           * the inserted element. We just remove it. This in turn creates several
+           * bugs when perfoming commands on selections that contain an empty text
+           * node (`removeFormat`, `unlink`).
+           * As per: http://jsbin.com/hajim/5/edit?js,console,output
+           */
+          // TODO: abstract into polyfill for `Range.insertNode`
+          if (startMarker.nextSibling &&
+              startMarker.nextSibling.nodeType === Node.TEXT_NODE
+              && startMarker.nextSibling.data === '') {
+            startMarker.parentNode.removeChild(startMarker.nextSibling);
+          }
+
+          /**
+           * Chrome and Firefox: `Range.insertNode` inserts a bogus text node
+           * before the inserted element when the child element is at the start of
+           * a block element. We just remove it.
+           * FIXME: Document why we need to remove this
+           * As per: http://jsbin.com/sifez/1/edit?js,console,output
+           */
+          if (startMarker.previousSibling &&
+              startMarker.previousSibling.nodeType === Node.TEXT_NODE
+              && startMarker.previousSibling.data === '') {
+            startMarker.parentNode.removeChild(startMarker.previousSibling);
+          }
+        }
+
+
+        this.selection.removeAllRanges();
+        this.selection.addRange(this.range);
       }
-
-
-      this.selection.removeAllRanges();
-      this.selection.addRange(this.range);
     };
 
     Selection.prototype.getMarkers = function () {

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -16,7 +16,7 @@ function (elementHelper) {
         this.range = this.selection.getRangeAt(0);
       }
     }
-    
+
     /**
      * @returns Closest ancestor Node satisfying nodeFilter. Undefined if none exist before reaching Scribe container.
      */
@@ -34,6 +34,13 @@ function (elementHelper) {
     Selection.prototype.placeMarkers = function () {
       var range = this.range;
       if(!range) { return; }
+
+      var scribeNodeRange = document.createRange();
+      scribeNodeRange.selectNodeContents(scribe.el);
+      //check if the END of the current selection is within the scribe node
+      if (scribeNodeRange.compareBoundaryPoints(Range.START_TO_END, this.range) < 0){
+        return;
+      }
 
       var startMarker = document.createElement('em');
       startMarker.classList.add('scribe-marker');

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -33,18 +33,26 @@ function (elementHelper) {
 
     Selection.prototype.placeMarkers = function () {
       var range = this.range;
-      if(!range) { return; }
+      if (!range) {
+        return;
+      }
 
-      var scribeNodeRange = document.createRange();
-      scribeNodeRange.selectNodeContents(scribe.el);
+      //we need to ensure that the scribe's element lives within the current document to avoid errors with the range comparison (see below)
+      //one way to do this is to check if it's visible (is this the best way?).
+      if (!scribe.el.offsetParent) {
+        return;
+      }
 
       //we want to ensure that the current selection is within the current scribe node
       //if this isn't true scribe will place markers within the selections parent
       //we want to ensure that scribe ONLY places markers within it's own element
+      var scribeNodeRange = document.createRange();
+      scribeNodeRange.selectNodeContents(scribe.el);
+
       var selectionStartWithinScribeElementStart = this.range.compareBoundaryPoints(Range.START_TO_START, scribeNodeRange) >= 0;
       var selectionEndWithinScribeElementEnd = this.range.compareBoundaryPoints(Range.END_TO_END, scribeNodeRange) <= 0;
 
-      if (selectionStartWithinScribeElementStart && selectionEndWithinScribeElementEnd){
+      if (selectionStartWithinScribeElementStart && selectionEndWithinScribeElementEnd) {
 
         var startMarker = document.createElement('em');
         startMarker.classList.add('scribe-marker');


### PR DESCRIPTION
Currently, if you have multiple scribe instances on a page and call `selection.placeMarkers()` each scribe instance will place markers around the current selection irrespective of whether that selection is within it's element. This causes multiple markers to be placed.

This PR adds a check to see if the current selection is within a scribe instances element. If not, it bails out.