### PR TITLE
API: use the Scribe root element to stop DOM traversal

### DIFF
--- a/src/api/node.js
+++ b/src/api/node.js
@@ -9,10 +9,9 @@ define(function () {
   // TODO: should the return value be wrapped in one of our APIs?
   // Node or Selection?
   // TODO: write tests. unit or integration?
-  Node.prototype.getAncestor = function (nodeFilter) {
+  Node.prototype.getAncestor = function (rootElement, nodeFilter) {
     var isTopContainerElement = function (element) {
-      return element && element.attributes
-        && element.attributes.getNamedItem('contenteditable');
+      return rootElement === element;
     };
     // TODO: should this happen here?
     if (isTopContainerElement(this.node)) {

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -25,8 +25,7 @@ function (elementHelper) {
       if (!range) { return; }
 
       var node = new scribe.api.Node(this.range.commonAncestorContainer);
-      var isTopContainerElement = node.node && node.node.attributes
-         && node.node.attributes.getNamedItem('contenteditable');
+      var isTopContainerElement = node.node && scribe.el === node.node;
 
       return ! isTopContainerElement && nodeFilter(node.node) ? node.node : node.getAncestor(nodeFilter);
     };

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -27,7 +27,7 @@ function (elementHelper) {
       var node = new scribe.api.Node(this.range.commonAncestorContainer);
       var isTopContainerElement = node.node && scribe.el === node.node;
 
-      return ! isTopContainerElement && nodeFilter(node.node) ? node.node : node.getAncestor(nodeFilter);
+      return ! isTopContainerElement && nodeFilter(node.node) ? node.node : node.getAncestor(scribe.el, nodeFilter);
     };
 
     Selection.prototype.placeMarkers = function () {


### PR DESCRIPTION
This picks up #308 and tries to use the element that the Scribe instance is bound to determine whether the searched element is at the root or not.

I'm not sure how much I trust the test suite on this but things are not broken &trade;