### PR TITLE
Fixing a bug caused when you automatically trigger focus

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -41,7 +41,7 @@ define([
           var isFirefoxBug = scribe.allowsBlockElements() &&
                   selection.range.startContainer === scribe.el;
 
-          if (isFirefoxBug) {
+          if (isFirefoxBug && scribe.el.firstChild) {
             var focusElement = getFirstDeepestChild(scribe.el.firstChild);
 
             var range = selection.range;


### PR DESCRIPTION
to scribe controlled DOM

How I'm triggering this:
```js
      var range = document.createRange();
      range.selectNodeContents(element);
      range.collapse(false);
      var selection = window.getSelection();
      selection.removeAllRanges();
      console.log(range);
      selection.addRange(range);
```