### PR TITLE
Add additional function arguments to document.createTreeWalker calls

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -216,7 +216,7 @@ function (elementHelper) {
       // return true if nested inline tags ultimately just contain <br> or ""
       function isEmptyInlineElement(node) {
 
-        var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
+        var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT, null, false);
 
         var currentNode = treeWalker.root;
 

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -55,7 +55,7 @@ define([
         }
 
         function getFirstDeepestChild(node) {
-          var treeWalker = document.createTreeWalker(node);
+          var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
           var previousNode = treeWalker.currentNode;
           if (treeWalker.firstChild()) {
             // TODO: build list of non-empty elements (used elsewhere)

--- a/src/plugins/core/formatters/html/enforce-p-elements.js
+++ b/src/plugins/core/formatters/html/enforce-p-elements.js
@@ -65,7 +65,7 @@ define([
 
   // Traverse the tree, wrapping child nodes as we go.
   function traverse(scribe, parentNode) {
-    var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
+    var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
     var node = treeWalker.firstChild();
 
     // FIXME: does this recurse down?

--- a/src/plugins/core/inline-elements-mode.js
+++ b/src/plugins/core/inline-elements-mode.js
@@ -4,7 +4,7 @@ define(function () {
 
   // TODO: abstract
   function hasContent(rootNode) {
-    var treeWalker = document.createTreeWalker(rootNode);
+    var treeWalker = document.createTreeWalker(rootNode, NodeFilter.SHOW_ALL, null, false);
 
     while (treeWalker.nextNode()) {
       if (treeWalker.currentNode) {

--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -26,7 +26,7 @@ define([], function () {
           sanitize(scribe.el);
 
           function sanitize(parentNode) {
-            var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT);
+            var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
             var node = treeWalker.firstChild();
             if (!node) { return; }
 


### PR DESCRIPTION
This is a small fix for IE compatibility. IE doesn't consider the arguments to createTreeWalker optional, so it bombs out if any are missing. This is causing observeDomChanges to break in IE11, and may well be breaking other stuff too.

Adding in the arguments with their default values should not cause any compatibility issues with other browsers.

See here for reference: https://developer.mozilla.org/en-US/docs/Web/API/Document.createTreeWalker