### PR TITLE
Prevent drag+drop breaking on IE11

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -155,7 +155,7 @@ define([
     if (skipFormatters) {
       this._skipFormatters = true;
     }
-    this.el.innerHTML = html;
+    if (this.el.innerHTML !== html) this.el.innerHTML = html;
   };
 
   Scribe.prototype.getHTML = function () {

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -155,7 +155,10 @@ define([
     if (skipFormatters) {
       this._skipFormatters = true;
     }
-    if (this.el.innerHTML !== html) this.el.innerHTML = html;
+    // IE11: Setting HTML to the value it already has causes breakages elsewhere (see #336)
+    if (this.el.innerHTML !== html) {
+      this.el.innerHTML = html;
+    }
   };
 
   Scribe.prototype.getHTML = function () {


### PR DESCRIPTION
This is a very odd glitch I've found when using Scribe core on IE11.

Basically, whenever you drag and drop text or other content within the editor (i.e. select text, move it somewhere else, deselect), it causes the entire editor to be blanked out.

The [scribe-plugin-curly-quotes](https://github.com/guardian/scribe-plugin-curly-quotes) and [scribe-plugin-sanitizer](https://github.com/guardian/scribe-plugin-sanitizer) plugins mask this problem on the demo, because they both cause a script error to occur before the action can finish.

I haven't been able to find the underlying cause for the bug, but I found a one-line change to `setHTML` fixes the problem. Basically avoid setting the HTML to the same value it already has and everything's just fine.