### PR TITLE
Fix/329 chrome shadow dom errors

### DIFF
--- a/BROWSERINCONSISTENCIES.md
+++ b/BROWSERINCONSISTENCIES.md
@@ -98,3 +98,14 @@ Playground: http://jsbin.com/iwEWUXo/2/edit?js,console,output
 ### `Range.commonAncestorContainer`
 * Firefox: Returns `P` when a whole `SUP` is selected:
   http://jsbin.com/xoqul/1/edit?js,console,output
+
+### `Selection.getRangeAt`
+* Chrome (< 42): Selection.getRangeAt() returns an incorrect range when in shadow DOM
+  https://code.google.com/p/chromium/issues/detail?id=380690
+
+### `Selection.isCollapsed`
+* Chrome: Selection.isCollapsed is incorrect when in shadow DOM
+  https://code.google.com/p/chromium/issues/detail?id=447523
+  http://jsfiddle.net/7zgegoda/2/
+
+

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -14,12 +14,12 @@ function (elementHelper) {
 
       // find the parent document or document fragment
       var currentElement = scribe.el.parentNode;
-      while(currentElement && currentElement.nodeType !== 11 && currentElement.nodeType !== 9) { // 11 = DOCUMENT_FRAGMENT_NODE, 9 = DOCUMENT
+      while(currentElement && currentElement.nodeType !== Node.DOCUMENT_FRAGMENT_NODE && currentElement.nodeType !== Node.DOCUMENT_NODE) {
         currentElement = currentElement.parentNode;
       }
 
       // if we found a document fragment and it has a getSelection method, set it to the root doc
-      if (currentElement.nodeType === 11 && currentElement.getSelection) {
+      if (currentElement.nodeType === Node.DOCUMENT_FRAGMENT_NODE && currentElement.getSelection) {
         rootDoc = currentElement;
       }
 

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -10,10 +10,26 @@ function (elementHelper) {
      * Wrapper for object holding currently selected text.
      */
     function Selection() {
-      this.selection = window.getSelection();
+      var rootDoc = document;
 
+      // find the parent document or document fragment
+      var currentElement = scribe.el.parentNode;
+      while(currentElement && currentElement.nodeType !== 11 && currentElement.nodeType !== 9) { // 11 = DOCUMENT_FRAGMENT_NODE, 9 = DOCUMENT
+        currentElement = currentElement.parentNode;
+      }
+
+      // if we found a document fragment and it has a getSelection method, set it to the root doc
+      if (currentElement.nodeType === 11 && currentElement.getSelection) {
+        rootDoc = currentElement;
+      }
+
+      this.selection = rootDoc.getSelection();
       if (this.selection.rangeCount) {
-        this.range = this.selection.getRangeAt(0);
+        // create the range to avoid chrome bug from getRangeAt / window.getSelection()
+        // https://code.google.com/p/chromium/issues/detail?id=380690
+        this.range = document.createRange();
+        this.range.setStart(this.selection.anchorNode, this.selection.anchorOffset);
+        this.range.setEnd(this.selection.focusNode, this.selection.focusOffset);
       }
     }
 

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -148,8 +148,8 @@ function (elementHelper) {
          * element [the text node] leaving the empty H2 behind.
          **/
 
-
-        if (! this.selection.isCollapsed) {
+        // using range.collapsed vs selection.isCollapsed - https://code.google.com/p/chromium/issues/detail?id=447523
+        if (! this.range.collapsed) {
           // Start marker
           var rangeStart = this.range.cloneRange();
           rangeStart.collapse(true);

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -19,7 +19,7 @@ function (elementHelper) {
       }
 
       // if we found a document fragment and it has a getSelection method, set it to the root doc
-      if (currentElement.nodeType === Node.DOCUMENT_FRAGMENT_NODE && currentElement.getSelection) {
+      if (currentElement && currentElement.nodeType === Node.DOCUMENT_FRAGMENT_NODE && currentElement.getSelection) {
         rootDoc = currentElement;
       }
 

--- a/src/plugins/core/patches/commands/create-link.js
+++ b/src/plugins/core/patches/commands/create-link.js
@@ -14,7 +14,8 @@ define(function () {
          * Firefox does not create a link when selection is collapsed
          * so we create it manually. http://jsbin.com/tutufi/2/edit?js,output
          */
-        if (selection.selection.isCollapsed) {
+        // using range.collapsed vs selection.isCollapsed - https://code.google.com/p/chromium/issues/detail?id=447523
+        if (selection.range.collapsed) {
           var aElement = document.createElement('a');
           aElement.setAttribute('href', value);
           aElement.textContent = value;


### PR DESCRIPTION
This is to fix issue #329. Scribe does not work in shadow DOM because it grabs the selection from the document rather then the parent document fragment (shadow root in this case).  I updated Selection to grab the appropriate document fragment to use to get the selection.

There is also 2x chrome bugs encountered when scribing in shadow root.  The first causes the selection.getRangeAt() method to return an incorrect range.  I checked Chrome Canary and found that the getRangeAt() issue is fixed in that version but I applied the workaround so scribe can be used for now (https://code.google.com/p/chromium/issues/detail?id=380690).

The second bug is not fixed in Canary and it causes selection.isCollapsed to be incorrect.  I found a workaround by calling range.collapsed (https://code.google.com/p/chromium/issues/detail?id=447523)

I tried to create some tests for these cases but was having trouble.  I think the scribe-test-harness will have to be modified to support testing scribe in a shadow root, and I'm not just not sure how to appropriately do that.  All of the current tests did pass in FF/Chrome.