### PR TITLE
insertHTML fix: don't purge user-generated SPANs

### DIFF
--- a/src/plugins/core/patches/commands/insert-html.js
+++ b/src/plugins/core/patches/commands/insert-html.js
@@ -11,46 +11,49 @@ define([], function () {
         scribe.transactionManager.run(function () {
           scribe.api.CommandPatch.prototype.execute.call(this, value);
 
+          // TODO: share somehow with similar event patch for P nodes
+          removeChromeArtifacts(scribe.el);
+
           /**
            * Chrome: If a parent node has a CSS `line-height` when we apply the
            * insertHTML command, Chrome appends a SPAN to plain content with
            * inline styling replicating that `line-height`, and adjusts the
            * `line-height` on inline elements.
+           * 
            * As per: http://jsbin.com/ilEmudi/4/edit?css,js,output
-           *
-           * FIXME: what if the user actually wants to use SPANs? This could
-           * cause conflicts.
+           * More from the web: http://stackoverflow.com/q/15015019/40352
            */
-
-          // TODO: share somehow with similar event patch for P nodes
-          sanitize(scribe.el);
-
-          function sanitize(parentNode) {
-            var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
-            var node = treeWalker.firstChild();
-            if (!node) { return; }
-
-            do {
-              if (node.nodeName === 'SPAN') {
-                element.unwrap(parentNode, node);
-              } else {
-                /**
-                 * If the list item contains inline elements such as
-                 * A, B, or I, Chrome will also append an inline style for
-                 * `line-height` on those elements, so we remove it here.
-                 */
-                node.style.lineHeight = null;
-
-                // There probably wasn’t a `style` attribute before, so
-                // remove it if it is now empty.
-                if (node.getAttribute('style') === '') {
-                  node.removeAttribute('style');
-                }
+          function removeChromeArtifacts(parentElement) {
+            // Can't use treeWalker: In at least Chrome, if a node is unwrapped,
+            // treeWalker.nextSibling will not work properly after that.
+            var childElement = parentElement.firstElementChild;
+            while (childElement) {
+              /**
+               * If the list item contains inline elements such as
+               * A, B, or I, Chrome will also append an inline style for
+               * `line-height` on those elements, so we remove it here.
+               */
+              var childStyle = window.getComputedStyle(childElement);
+              if ((childStyle.display === 'inline' || childElement.nodeName === 'SPAN') && window.getComputedStyle(parentElement)['line-height'] === childStyle['line-height']) {
+                childElement.style.lineHeight = null;
               }
-
-              // Sanitize children
-              sanitize(node);
-            } while ((node = treeWalker.nextSibling()));
+              
+              // We can discard an empty style attribute.
+              if (childElement.getAttribute('style') === '') {
+                childElement.removeAttribute('style');
+              }
+              
+              // Sanitize children.
+              removeChromeArtifacts(childElement);
+              
+              // We can discard an empty SPAN.
+              // (Don't do this until traversal's gone to the next element.)
+              var originalChild = childElement;
+              childElement = childElement.nextElementSibling;
+              if (originalChild.nodeName === 'SPAN' && originalChild.attributes.length === 0) {
+                element.unwrap(parentElement, originalChild);
+              }
+            }
           }
         }.bind(this));
       };


### PR DESCRIPTION
A while back, this was written in insert-html.js: "FIXME: what if the user actually wants to use SPANs? This could cause conflicts."
Turns out that user was me. This updated patch is more targeted, removing only SPANs that are truly superfluous. In addition, it also covers more than one SPAN, where the original code would only cover the first child SPAN.

I've only tested this fix on my own code.