### PR TITLE
Superficial (non-functionality affecting) changes

### DIFF
--- a/src/api/simple-command.js
+++ b/src/api/simple-command.js
@@ -6,7 +6,7 @@ define(function () {
     function SimpleCommand(commandName, nodeName) {
       scribe.api.Command.call(this, commandName);
 
-      this.nodeName = nodeName;
+      this._nodeName = nodeName;
     }
 
     SimpleCommand.prototype = Object.create(api.Command.prototype);
@@ -15,7 +15,7 @@ define(function () {
     SimpleCommand.prototype.queryState = function () {
       var selection = new scribe.api.Selection();
       return scribe.api.Command.prototype.queryState.call(this) && !! selection.getContaining(function (node) {
-        return node.nodeName === this.nodeName;
+        return node.nodeName === this._nodeName;
       }.bind(this));
     };
 

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -257,7 +257,12 @@ define([
   Scribe.prototype.isDebugModeEnabled = function () {
     return this.options.debug;
   };
-
+  
+  /**
+   * Applies HTML formatting to all editor text.
+   * @param {String} phase sanitize/normalize/export are the standard phases
+   * @param {Function} fn Function that takes the current editor HTML and returns a formatted version.
+   */
   Scribe.prototype.registerHTMLFormatter = function (phase, fn) {
     this._htmlFormatterFactory.formatters[phase]
       = this._htmlFormatterFactory.formatters[phase].push(fn);


### PR DESCRIPTION
When creating my own Commands, I had to search through the codebase to determine that nodeName was not being used externally; this small visual change helps to make it clear that implementors of Command need not implement nodeName.