### PR TITLE
Selection API range property is incorrect for "backwards" selection

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -28,8 +28,19 @@ function (elementHelper) {
         // create the range to avoid chrome bug from getRangeAt / window.getSelection()
         // https://code.google.com/p/chromium/issues/detail?id=380690
         this.range = document.createRange();
+        var reverseRange = document.createRange();
+
         this.range.setStart(this.selection.anchorNode, this.selection.anchorOffset);
-        this.range.setEnd(this.selection.focusNode, this.selection.focusOffset);
+        reverseRange.setStart(this.selection.focusNode, this.selection.focusOffset);
+
+        // Check if anchorNode is before focusNode, use reverseRange if not
+        if (this.range.compareBoundaryPoints(Range.START_TO_START, reverseRange) <= 0) {
+          this.range.setEnd(this.selection.focusNode, this.selection.focusOffset);
+        }
+        else {
+          this.range = reverseRange;
+          this.range.setEnd(this.selection.anchorNode, this.selection.anchorOffset);
+        }
       }
     }
 


### PR DESCRIPTION
This is a bug which looks to have been introduced by [edd638f], where `getRangeAt(0)` was replaced with a `createRange` routine.

The issue is that if you select some text backwards, i.e. anchorNode is after focusNode, the range will be empty, because although Selection is "backwards"-compatible, Range is not.

Here's a JSbin which demonstrates the issue: http://jsbin.com/wujuropeye/1/edit?html,js,output