### PR TITLE
Added "shouldUndo" to scribe options for optional undo management

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Alternatively, you can [access the distribution files through GitHub releases](h
   <dt><pre>allowBlockElements</pre></dt>
   <dd>Enable/disable block element mode (enabled by default)</dd>
   <dt><pre>defaultCommandPatches</pre></dt>
-  <dd>Defines which command patches should be loaded by default</dd> 
+  <dd>Defines which command patches should be loaded by default</dd>
+  <dt><pre>undo: { enabled: false }</pre></dt>
+  <dd>Enable/disable Scribe's custom undo manager</dd>
 </dl>
 
 ## Usage Example
@@ -185,6 +187,15 @@ this behaviour Scribe needs to manipulate the DOM once again.
 
 The undo stack breaks whenever DOM manipulation is used instead of the native
 command API, therefore we have to use our own.
+
+Scribe's undo manager can be turned off by configuration eg:
+``` js
+var scribe = new Scribe(scribeElement, {
+  undo: {
+    enabled: false
+  }
+})
+```
 
 [browser inconsistencies]: https://github.com/guardian/scribe/blob/master/BROWSERINCONSISTENCIES.md
 [Executing Commands]: https://developer.mozilla.org/en-US/docs/Rich-Text_Editing_in_Mozilla#Executing_Commands

--- a/src/plugins/core/commands/redo.js
+++ b/src/plugins/core/commands/redo.js
@@ -7,6 +7,7 @@ define(function () {
       var redoCommand = new scribe.api.Command('redo');
 
       redoCommand.execute = function () {
+
         var historyItem = scribe.undoManager.redo();
 
         if (typeof historyItem !== 'undefined') {
@@ -20,12 +21,15 @@ define(function () {
 
       scribe.commands.redo = redoCommand;
 
-      scribe.el.addEventListener('keydown', function (event) {
-        if (event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {
-          event.preventDefault();
-          redoCommand.execute();
-        }
-      });
+      //is scribe is configured to undo assign listener
+      if (scribe.options.shouldUndo) {
+        scribe.el.addEventListener('keydown', function (event) {
+          if (event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {
+            event.preventDefault();
+            redoCommand.execute();
+          }
+        });
+      }
     };
   };
 

--- a/src/plugins/core/commands/redo.js
+++ b/src/plugins/core/commands/redo.js
@@ -22,7 +22,7 @@ define(function () {
       scribe.commands.redo = redoCommand;
 
       //is scribe is configured to undo assign listener
-      if (scribe.options.shouldUndo) {
+      if (scribe.options.undo.enabled) {
         scribe.el.addEventListener('keydown', function (event) {
           if (event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {
             event.preventDefault();

--- a/src/plugins/core/commands/undo.js
+++ b/src/plugins/core/commands/undo.js
@@ -20,13 +20,15 @@ define(function () {
 
       scribe.commands.undo = undoCommand;
 
-      scribe.el.addEventListener('keydown', function (event) {
-        // TODO: use lib to abstract meta/ctrl keys?
-        if (! event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {
-          event.preventDefault();
-          undoCommand.execute();
-        }
-      });
+      if(scribe.options.shouldUndo){
+        scribe.el.addEventListener('keydown', function (event) {
+          // TODO: use lib to abstract meta/ctrl keys?
+          if (! event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {
+            event.preventDefault();
+            undoCommand.execute();
+          }
+        });
+      }
     };
   };
 

--- a/src/plugins/core/commands/undo.js
+++ b/src/plugins/core/commands/undo.js
@@ -20,7 +20,7 @@ define(function () {
 
       scribe.commands.undo = undoCommand;
 
-      if(scribe.options.shouldUndo){
+      if (scribe.options.shouldUndo) {
         scribe.el.addEventListener('keydown', function (event) {
           // TODO: use lib to abstract meta/ctrl keys?
           if (! event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {

--- a/src/plugins/core/commands/undo.js
+++ b/src/plugins/core/commands/undo.js
@@ -20,7 +20,7 @@ define(function () {
 
       scribe.commands.undo = undoCommand;
 
-      if (scribe.options.shouldUndo) {
+      if (scribe.options.undo.enabled) {
         scribe.el.addEventListener('keydown', function (event) {
           // TODO: use lib to abstract meta/ctrl keys?
           if (! event.shiftKey && (event.metaKey || event.ctrlKey) && event.keyCode === 90) {

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -92,9 +92,9 @@ define([
           // `scribe.setContent`), we do not want to push to the history. (This
           // happens on the first `focus` event).
           if (isEditorActive) {
-            // Discard the last history item, as we're going to be adding
-            // a new clean history item next.
             if (scribe.options.shouldUndo) {
+              // Discard the last history item, as we're going to be adding
+              // a new clean history item next.
               scribe.undoManager.undo();
             }
 

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -92,7 +92,7 @@ define([
           // `scribe.setContent`), we do not want to push to the history. (This
           // happens on the first `focus` event).
           if (isEditorActive) {
-            if (scribe.options.shouldUndo) {
+            if (scribe.undoManager) {
               // Discard the last history item, as we're going to be adding
               // a new clean history item next.
               scribe.undoManager.undo();

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -94,7 +94,9 @@ define([
           if (isEditorActive) {
             // Discard the last history item, as we're going to be adding
             // a new clean history item next.
-            scribe.undoManager.undo();
+            if (scribe.options.shouldUndo) {
+              scribe.undoManager.undo();
+            }
 
             // Pass content through formatters, place caret back
             scribe.transactionManager.run(runFormatters);

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -47,7 +47,9 @@ define([], function () {
                * it's too late to cancel it at this stage (and it's
                * not happened yet at keydown time).
                */
-              scribe.undoManager.undo();
+              if (scribe.options.shouldUndo) {
+                scribe.undoManager.undo();
+              }
 
               scribe.transactionManager.run(function () {
                 // Store the caret position

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -47,7 +47,7 @@ define([], function () {
                * it's too late to cancel it at this stage (and it's
                * not happened yet at keydown time).
                */
-              if (scribe.options.shouldUndo) {
+              if (scribe.undoManager) {
                 scribe.undoManager.undo();
               }
 

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -72,7 +72,7 @@ define([
     var TransactionManager = buildTransactionManager(this);
     this.transactionManager = new TransactionManager();
 
-    if(this.options.shouldUndo){
+    if (this.options.shouldUndo) {
       var UndoManager = buildUndoManager(this);
       this.undoManager = new UndoManager();
     }
@@ -178,7 +178,7 @@ define([
   };
 
   Scribe.prototype.pushHistory = function () {
-    if(this.options.shouldUndo){
+    if (this.options.shouldUndo) {
       var previousUndoItem = this.undoManager.stack[this.undoManager.position];
       var previousContent = previousUndoItem && previousUndoItem
         .replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '');

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -47,7 +47,7 @@ define([
     this.options = defaults(options || {}, {
       allowBlockElements: true,
       debug: false,
-      shouldUndo: true,
+      undo: { enabled: true },
       defaultCommandPatches: [
         'bold',
         'indent',
@@ -72,7 +72,9 @@ define([
     var TransactionManager = buildTransactionManager(this);
     this.transactionManager = new TransactionManager();
 
-    if (this.options.shouldUndo) {
+    //added for explicit checking later eg if (scribe.undoManager) { ... }
+    this.undoManager = false;
+    if (this.options.undo.enabled) {
       var UndoManager = buildUndoManager(this);
       this.undoManager = new UndoManager();
     }
@@ -178,7 +180,7 @@ define([
   };
 
   Scribe.prototype.pushHistory = function () {
-    if (this.options.shouldUndo) {
+    if (this.options.undo.enabled) {
       var previousUndoItem = this.undoManager.stack[this.undoManager.position];
       var previousContent = previousUndoItem && previousUndoItem
         .replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '');

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -47,6 +47,7 @@ define([
     this.options = defaults(options || {}, {
       allowBlockElements: true,
       debug: false,
+      shouldUndo: true,
       defaultCommandPatches: [
         'bold',
         'indent',
@@ -71,8 +72,10 @@ define([
     var TransactionManager = buildTransactionManager(this);
     this.transactionManager = new TransactionManager();
 
-    var UndoManager = buildUndoManager(this);
-    this.undoManager = new UndoManager();
+    if(this.options.shouldUndo){
+      var UndoManager = buildUndoManager(this);
+      this.undoManager = new UndoManager();
+    }
 
     this.el.setAttribute('contenteditable', true);
 
@@ -175,30 +178,35 @@ define([
   };
 
   Scribe.prototype.pushHistory = function () {
-    var previousUndoItem = this.undoManager.stack[this.undoManager.position];
-    var previousContent = previousUndoItem && previousUndoItem
-      .replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '');
+    if(this.options.shouldUndo){
+      var previousUndoItem = this.undoManager.stack[this.undoManager.position];
+      var previousContent = previousUndoItem && previousUndoItem
+        .replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '');
 
-    /**
-     * Chrome and Firefox: If we did push to the history, this would break
-     * browser magic around `Document.queryCommandState` (http://jsbin.com/eDOxacI/1/edit?js,console,output).
-     * This happens when doing any DOM manipulation.
-     */
+      /**
+       * Chrome and Firefox: If we did push to the history, this would break
+       * browser magic around `Document.queryCommandState` (http://jsbin.com/eDOxacI/1/edit?js,console,output).
+       * This happens when doing any DOM manipulation.
+       */
 
-    // We only want to push the history if the content actually changed.
-    if (! previousUndoItem || (previousUndoItem && this.getHTML() !== previousContent)) {
-      var selection = new this.api.Selection();
+      // We only want to push the history if the content actually changed.
+      if (! previousUndoItem || (previousUndoItem && this.getHTML() !== previousContent)) {
+        var selection = new this.api.Selection();
 
-      selection.placeMarkers();
-      var html = this.getHTML();
-      selection.removeMarkers();
+        selection.placeMarkers();
+        var html = this.getHTML();
+        selection.removeMarkers();
 
-      this.undoManager.push(html);
+        this.undoManager.push(html);
 
-      return true;
+        return true;
+      } else {
+        return false;
+      }
     } else {
       return false;
     }
+
   };
 
   Scribe.prototype.getCommand = function (commandName) {
@@ -260,7 +268,7 @@ define([
   Scribe.prototype.isDebugModeEnabled = function () {
     return this.options.debug;
   };
-  
+
   /**
    * Applies HTML formatting to all editor text.
    * @param {String} phase sanitize/normalize/export are the standard phases


### PR DESCRIPTION
As mentioned here: https://github.com/guardian/scribe-plugin-advanced-undo/pull/1 I've tried to make scribe undo functionality optional by configuration. Not 100% sure of all the impacts of this so would be good to get eyes @rrees @hmgibson23 @robinedman @jamespamplin @theefer  

NB: all the tests run locally.