### PR TITLE
UndoManager Improvements

### DIFF
--- a/examples/shared-undo-manager.html
+++ b/examples/shared-undo-manager.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Shared UndoManager</title>
+  <style>
+  #wrapper {
+    width: 90%;
+    margin: 0 auto;
+  }
+
+  #editor1, #editor2, #output, #stack {
+    display: block;
+    border: 1px solid gray;
+    height: 100px;
+    width: 100%;
+    padding: 5px;
+    overflow: auto;
+    resize: none;
+  }
+
+  p {
+    margin: 8px 0;
+  }
+  </style>
+</head>
+<body>
+  <div id="wrapper">
+    <h2>Editor 1</h2>
+    <div id="editor1"></div>
+    <h2>Editor 2</h2>
+    <div id="editor2"></div>
+    <h2>Output</h2>
+    <textarea id="output" readonly></textarea>
+    <h2>UndoManager Stack</h2>
+    <textarea id="stack" readonly></textarea>
+  </div>
+  <script src="../bower_components/requirejs/require.js"></script>
+  <script>
+  require({
+    paths: {
+      'lodash-amd': '../bower_components/lodash-amd',
+      'immutable': '../bower_components/immutable'
+    }
+  }, [
+    '../src/scribe',
+    '../src/undo-manager'
+  ], function (
+    Scribe,
+    UndoManager
+  ) {
+    var editor1 = document.querySelector('#editor1');
+    var editor2 = document.querySelector('#editor2');
+    var output = document.querySelector('#output');
+    var stack = document.querySelector('#stack');
+
+    var undoManager = new UndoManager(40, document);
+    document.addEventListener('DOMTransaction', update);
+    document.addEventListener('undo', update);
+    document.addEventListener('redo', update);
+
+
+    var scribe1 = new Scribe(editor1, {undo: {enabled: true, manager: undoManager, interval: 1000}});
+    scribe1.on('content-changed', update);
+
+    var scribe2 = new Scribe(editor2, {undo: {enabled: true, manager: undoManager, interval: 1000}});
+    scribe2.on('content-changed', update);
+
+    function update() {
+      output.value = 'Edit 1:\n' + scribe1.getHTML() + '\n\nEdit 2:\n' + scribe2.getHTML();
+      // for debugging
+      stack.value = '';
+      for (var i = 0; i <= undoManager.length; i++) {
+        stack.value += (undoManager.position == i ? '> ' : '  ');
+        if (i < undoManager.length) {
+          var item = undoManager.item(i)[0];
+          stack.value += '[' + (item.scribe == scribe1 ? 'editor1' : 'editor2');
+          stack.value += ': ' + item.content.replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '|') + ']\n';
+        }
+        else if (i == undoManager.length) {
+          var item = undoManager.item(i - 1)[0];
+          stack.value += '[' + (item.scribe == scribe1 ? 'editor1' : 'editor2');
+          stack.value += ': ' + item.previousItem.content.replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '|') + ']\n';
+        }
+      }
+    }
+
+    update();
+  });
+  </script>
+</body>
+</html>

--- a/src/plugins/core/commands/redo.js
+++ b/src/plugins/core/commands/redo.js
@@ -7,16 +7,11 @@ define(function () {
       var redoCommand = new scribe.api.Command('redo');
 
       redoCommand.execute = function () {
-
-        var historyItem = scribe.undoManager.redo();
-
-        if (typeof historyItem !== 'undefined') {
-          scribe.restoreFromHistory(historyItem);
-        }
+        scribe.undoManager.redo();
       };
 
       redoCommand.queryEnabled = function () {
-        return scribe.undoManager.position < scribe.undoManager.stack.length - 1;
+        return scribe.undoManager.position > 0;
       };
 
       scribe.commands.redo = redoCommand;

--- a/src/plugins/core/commands/undo.js
+++ b/src/plugins/core/commands/undo.js
@@ -7,15 +7,11 @@ define(function () {
       var undoCommand = new scribe.api.Command('undo');
 
       undoCommand.execute = function () {
-        var historyItem = scribe.undoManager.undo();
-
-        if (typeof historyItem !== 'undefined') {
-          scribe.restoreFromHistory(historyItem);
-        }
+        scribe.undoManager.undo();
       };
 
       undoCommand.queryEnabled = function () {
-        return scribe.undoManager.position > 1;
+        return scribe.undoManager.position < scribe.undoManager.length;
       };
 
       scribe.commands.undo = undoCommand;

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -91,13 +91,14 @@ define([
           // active. If the DOM is mutated when the editor isn't active (e.g.
           // `scribe.setContent`), we do not want to push to the history. (This
           // happens on the first `focus` event).
-          if (isEditorActive) {
-            // Pass content through formatters, place caret back
-            scribe.transactionManager.run(runFormatters);
-          } else {
-            runFormatters();
-          }
 
+          // The previous check is no longer needed, and the above comments are no longer valid.
+          // Now `scribe.setContent` updates the content manually, and `scribe.pushHistory`
+          // will not detect any changes, and nothing will be push into the history.
+          // Any mutations made without `scribe.getContent` will be pushed into the history normally.
+
+          // Pass content through formatters, place caret back
+          scribe.transactionManager.run(runFormatters);
         }
 
         delete scribe._skipFormatters;

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -11,20 +11,6 @@ define([
   return function () {
     return function (scribe) {
       /**
-       * Push the first history item when the editor is focused.
-       */
-      var pushHistoryOnFocus = function () {
-        // Tabbing into the editor doesn't create a range immediately, so we
-        // have to wait until the next event loop.
-        setTimeout(function () {
-          scribe.pushHistory();
-        }.bind(scribe), 0);
-
-        scribe.el.removeEventListener('focus', pushHistoryOnFocus);
-      }.bind(scribe);
-      scribe.el.addEventListener('focus', pushHistoryOnFocus);
-
-      /**
        * Firefox: Giving focus to a `contenteditable` will place the caret
        * outside of any block elements. Chrome behaves correctly by placing the
        * caret at the  earliest point possible inside the first block element.

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -92,12 +92,6 @@ define([
           // `scribe.setContent`), we do not want to push to the history. (This
           // happens on the first `focus` event).
           if (isEditorActive) {
-            if (scribe.undoManager) {
-              // Discard the last history item, as we're going to be adding
-              // a new clean history item next.
-              scribe.undoManager.undo();
-            }
-
             // Pass content through formatters, place caret back
             scribe.transactionManager.run(runFormatters);
           } else {

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -47,9 +47,9 @@ define([], function () {
                * it's too late to cancel it at this stage (and it's
                * not happened yet at keydown time).
                */
-              if (scribe.undoManager) {
-                scribe.undoManager.undo();
-              }
+              //if (scribe.undoManager) {
+              //  scribe.undoManager.undo();
+              //}
 
               scribe.transactionManager.run(function () {
                 // Store the caret position

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -38,9 +38,9 @@ define([], function () {
               /**
                * The 'input' event listener has already triggered
                * and recorded the faulty content as an item in the
-               * UndoManager.  We interfere with the undoManager
-               * here to discard that history item, and let the next
-               * transaction run produce a clean one instead.
+               * UndoManager. We interfere with the undoManager
+               * by force merging that transaction with the next
+               * transaction which produce a clean one instead.
                *
                * FIXME: ideally we would not trigger a
                * 'content-changed' event with faulty HTML at all, but
@@ -78,7 +78,7 @@ define([], function () {
                 });
 
                 selection.selectMarkers();
-              });
+              }, true);
             }
           }
         });

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -47,9 +47,6 @@ define([], function () {
                * it's too late to cancel it at this stage (and it's
                * not happened yet at keydown time).
                */
-              //if (scribe.undoManager) {
-              //  scribe.undoManager.undo();
-              //}
 
               scribe.transactionManager.run(function () {
                 // Store the caret position

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -47,7 +47,7 @@ define([
     this.options = defaults(options || {}, {
       allowBlockElements: true,
       debug: false,
-      undo: { enabled: true, limit: 100, interval: 1000 },
+      undo: { manager: null, enabled: true, limit: 100, interval: 1000 },
       defaultCommandPatches: [
         'bold',
         'indent',
@@ -75,11 +75,18 @@ define([
     //added for explicit checking later eg if (scribe.undoManager) { ... }
     this.undoManager = false;
     if (this.options.undo.enabled) {
-      this.undoManager = new UndoManager(this.options.undo.limit, this.el);
+      if (this.options.undo.manager) {
+        this.undoManager = this.options.undo.manager;
+      }
+      else {
+        this.undoManager = new UndoManager(this.options.undo.limit, this.el);
+      }
       this._merge = false;
       this._forceMerge = false;
       this._mergeTimer = 0;
     }
+
+    this.setHTML(this.getHTML());
 
     this.el.setAttribute('contenteditable', true);
 
@@ -168,7 +175,6 @@ define([
     }
 
     this._previousContent = this.getHTML();
-    console.log(this._previousContent);
   };
 
   Scribe.prototype.getHTML = function () {

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -50,7 +50,7 @@ define([
     this.options = defaults(options || {}, {
       allowBlockElements: true,
       debug: false,
-      undo: { enabled: true, interval: 1000 },
+      undo: { enabled: true, interval: 0, limit: 100 },
       defaultCommandPatches: [
         'bold',
         'indent',
@@ -78,7 +78,7 @@ define([
     //added for explicit checking later eg if (scribe.undoManager) { ... }
     this.undoManager = false;
     if (this.options.undo.enabled) {
-      this.undoManager = new UndoManager(100, this.el);
+      this.undoManager = new UndoManager(this.options.undo.limit, this.el);
     }
 
     this.el.setAttribute('contenteditable', true);
@@ -195,7 +195,7 @@ define([
        */
 
       // We only want to push the history if the content actually changed.
-      if (! previousUndoItem || (previousUndoItem && this.getHTML() !== previousContentNoMarker)) {
+      if (this.undoManager.length == 0 || this.getHTML() !== previousContentNoMarker) {
         var selection = new this.api.Selection();
 
         selection.placeMarkers();

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -204,7 +204,7 @@ define([
 
         // Register a new change transaction.
         var scribe = this;
-        this.undoManager.transact({
+        scribe.undoManager.transact({
           previousContent: previousContent,
           content: html,
           scribe: scribe,

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -79,7 +79,6 @@ define([
       this._merge = false;
       this._forceMerge = false;
       this._mergeTimer = 0;
-      this._previousContent = this.getHTML();
     }
 
     this.el.setAttribute('contenteditable', true);
@@ -167,6 +166,9 @@ define([
     if (this.el.innerHTML !== html) {
       this.el.innerHTML = html;
     }
+
+    this._previousContent = this.getHTML();
+    console.log(this._previousContent);
   };
 
   Scribe.prototype.getHTML = function () {
@@ -193,11 +195,11 @@ define([
     if (scribe.options.undo.enabled) {
       // Get scribe previous content, and strip markers.
       var previousContent = scribe._previousContent;
-      var previousContentNoMarker = previousContent && previousContent
+      var previousContentNoMarkers = previousContent && previousContent
         .replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '');
 
       // We only want to push the history if the content actually changed.
-      if (scribe.getHTML() !== previousContentNoMarker) {
+      if (scribe.getHTML() !== previousContentNoMarkers) {
         var selection = new scribe.api.Selection();
 
         selection.placeMarkers();
@@ -213,7 +215,6 @@ define([
         if ((scribe._merge || scribe._forceMerge) && lastItem && scribe == lastItem[0].scribe) {
           // Merge manually with the last item to save more memory space.
           lastItem[0].content = content;
-
         }
         else {
           // Otherwise, register a new transaction.
@@ -226,7 +227,6 @@ define([
             redo: function () { this.scribe.restoreFromHistory(this.content); }
           }, false);
         }
-        scribe._previousContent = content;
 
         // Merge next transaction if it happens before the interval option, otherwise don't merge.
         clearTimeout(scribe._mergeTimer);
@@ -268,7 +268,6 @@ define([
     }
 
     this.setHTML(content);
-    this._previousContent = content;
 
     this.trigger('content-changed');
   };

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -50,7 +50,7 @@ define([
     this.options = defaults(options || {}, {
       allowBlockElements: true,
       debug: false,
-      undo: { enabled: true, interval: 0, limit: 100 },
+      undo: { enabled: true, interval: 50, limit: 100 },
       defaultCommandPatches: [
         'bold',
         'indent',

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -181,14 +181,6 @@ define([
     return this.el.textContent;
   };
 
-  /**
-   * Replace the current undo manager. Can be used by undo manager plugins or directly by the user.
-   * @param {Object} undoManager The undo manager instance to be used by the current editor.
-   */
-  Scribe.prototype.setUndoManager = function (undoManager) {
-	  this.undoManager = undoManager;
-  };
-
   Scribe.prototype.pushHistory = function () {
     if (this.options.undo.enabled) {
       var previousUndoItem = this.undoManager.item(this.undoManager.position);
@@ -215,7 +207,7 @@ define([
         this.undoManager.transact({
           previousContent: previousContent,
           content: html,
-		  scribe: scribe,
+          scribe: scribe,
           execute: function () { },
           undo: function () { this.scribe.restoreFromHistory(this.previousContent); },
           redo: function () { this.scribe.restoreFromHistory(this.content); }

--- a/src/transaction-manager.js
+++ b/src/transaction-manager.js
@@ -21,7 +21,7 @@ define(['lodash-amd/modern/objects/assign'], function (assign) {
         }
       },
 
-      run: function (transaction) {
+      run: function (transaction, forceMerge) {
         this.start();
         // If there is an error, don't prevent the transaction from ending.
         try {
@@ -29,7 +29,9 @@ define(['lodash-amd/modern/objects/assign'], function (assign) {
             transaction();
           }
         } finally {
+          scribe._forceMerge = forceMerge === true;
           this.end();
+          scribe._forceMerge = false;
         }
       }
     });

--- a/src/undo-manager.js
+++ b/src/undo-manager.js
@@ -9,52 +9,63 @@ define(function () {
 		this.length = 0;
 
 		this.transact = function (transaction, merge) {
-			if (arguments.length < 2)
+			if (arguments.length < 2) {
 				throw new TypeError('Not enough arguments to UndoManager.transact.');
+			}
 
 			transaction.execute();
 
 			stack.splice(0, this.position);
-			if (merge && this.length)
+			if (merge && this.length) {
 				stack[0].push(transaction);
-			else
+			}
+			else {
 				stack.unshift([transaction]);
+			}
 			this.position = 0;
 
-			if (limit && stack.length > limit)
+			if (limit && stack.length > limit) {
 				this.length = stack.length = limit;
-			else
+			}
+			else {
 				this.length = stack.length;
+			}
 
-			if (fireEvent)
+			if (fireEvent) {
 				undoScopeHost.dispatchEvent(new CustomEvent('DOMTransaction', {detail: {transactions: stack[0].slice()}, bubbles: true, cancelable: false}));
+			}
 		};
 
 		this.undo = function () {
 			if (this.position < this.length) {
-				for (var i = stack[this.position].length - 1; i >= 0; i--)
+				for (var i = stack[this.position].length - 1; i >= 0; i--) {
 					stack[this.position][i].undo();
+				}
 				this.position++;
 
-				if (fireEvent)
+				if (fireEvent) {
 					undoScopeHost.dispatchEvent(new CustomEvent('undo', {detail: {transactions: stack[this.position - 1].slice()}, bubbles: true, cancelable: false}));
+				}
 			}
 		};
 
 		this.redo = function () {
 			if (this.position > 0) {
-				for (var i = 0, n = stack[this.position - 1].length; i < n; i++)
+				for (var i = 0, n = stack[this.position - 1].length; i < n; i++) {
 					stack[this.position - 1][i].redo();
+				}
 				this.position--;
 
-				if (fireEvent)
+				if (fireEvent) {
 					undoScopeHost.dispatchEvent(new CustomEvent('redo', {detail: {transactions: stack[this.position].slice()}, bubbles: true, cancelable: false}));
+				}
 			}
 		};
 
 		this.item = function (index) {
-			if (index >= 0 && index < this.length)
+			if (index >= 0 && index < this.length) {
 				return stack[index].slice();
+			}
 			return null;
 		};
 

--- a/src/undo-manager.js
+++ b/src/undo-manager.js
@@ -2,83 +2,86 @@ define(function () {
   'use strict';
 
   function UndoManager(limit, undoScopeHost) {
-    var stack = [];
-    var fireEvent = typeof CustomEvent != 'undefined' && undoScopeHost && undoScopeHost.dispatchEvent;
+    this._stack = [];
+    this._limit = limit;
+    this._fireEvent = typeof CustomEvent != 'undefined' && undoScopeHost && undoScopeHost.dispatchEvent;
+    this._ush = undoScopeHost;
 
     this.position = 0;
     this.length = 0;
-
-    this.transact = function (transaction, merge) {
-      if (arguments.length < 2) {
-        throw new TypeError('Not enough arguments to UndoManager.transact.');
-      }
-
-      transaction.execute();
-
-      stack.splice(0, this.position);
-      if (merge && this.length) {
-        stack[0].push(transaction);
-      }
-      else {
-        stack.unshift([transaction]);
-      }
-      this.position = 0;
-
-      if (limit && stack.length > limit) {
-        this.length = stack.length = limit;
-      }
-      else {
-        this.length = stack.length;
-      }
-
-      if (fireEvent) {
-        undoScopeHost.dispatchEvent(new CustomEvent('DOMTransaction', {detail: {transactions: stack[0].slice()}, bubbles: true, cancelable: false}));
-      }
-    };
-
-    this.undo = function () {
-      if (this.position < this.length) {
-        for (var i = stack[this.position].length - 1; i >= 0; i--) {
-          stack[this.position][i].undo();
-        }
-        this.position++;
-
-        if (fireEvent) {
-          undoScopeHost.dispatchEvent(new CustomEvent('undo', {detail: {transactions: stack[this.position - 1].slice()}, bubbles: true, cancelable: false}));
-        }
-      }
-    };
-
-    this.redo = function () {
-      if (this.position > 0) {
-        for (var i = 0, n = stack[this.position - 1].length; i < n; i++) {
-          stack[this.position - 1][i].redo();
-        }
-        this.position--;
-
-        if (fireEvent) {
-          undoScopeHost.dispatchEvent(new CustomEvent('redo', {detail: {transactions: stack[this.position].slice()}, bubbles: true, cancelable: false}));
-        }
-      }
-    };
-
-    this.item = function (index) {
-      if (index >= 0 && index < this.length) {
-        return stack[index].slice();
-      }
-      return null;
-    };
-
-    this.clearUndo = function () {
-      stack.length = this.length = this.position;
-    };
-
-    this.clearRedo = function () {
-      stack.splice(0, this.position);
-      this.position = 0;
-      this.length = stack.length;
-    };
   }
+
+  UndoManager.prototype.transact = function (transaction, merge) {
+    if (arguments.length < 2) {
+      throw new TypeError('Not enough arguments to UndoManager.transact.');
+    }
+
+    transaction.execute();
+
+    this._stack.splice(0, this.position);
+    if (merge && this.length) {
+      this._stack[0].push(transaction);
+    }
+    else {
+      this._stack.unshift([transaction]);
+    }
+    this.position = 0;
+
+    if (this._limit && this._stack.length > this._limit) {
+      this.length = this._stack.length = this._limit;
+    }
+    else {
+      this.length = this._stack.length;
+    }
+
+    if (this._fireEvent) {
+      this._ush.dispatchEvent(new CustomEvent('DOMTransaction', {detail: {transactions: this._stack[0].slice()}, bubbles: true, cancelable: false}));
+    }
+  };
+
+  UndoManager.prototype.undo = function () {
+    if (this.position < this.length) {
+      for (var i = this._stack[this.position].length - 1; i >= 0; i--) {
+        this._stack[this.position][i].undo();
+      }
+      this.position++;
+
+      if (this._fireEvent) {
+        this._ush.dispatchEvent(new CustomEvent('undo', {detail: {transactions: this._stack[this.position - 1].slice()}, bubbles: true, cancelable: false}));
+      }
+    }
+  };
+
+  UndoManager.prototype.redo = function () {
+    if (this.position > 0) {
+      for (var i = 0, n = this._stack[this.position - 1].length; i < n; i++) {
+        this._stack[this.position - 1][i].redo();
+      }
+      this.position--;
+
+      if (this._fireEvent) {
+        this._ush.dispatchEvent(new CustomEvent('redo', {detail: {transactions: this._stack[this.position].slice()}, bubbles: true, cancelable: false}));
+      }
+    }
+  };
+
+  UndoManager.prototype.item = function (index) {
+    if (index >= 0 && index < this.length) {
+      return this._stack[index].slice();
+    }
+    return null;
+  };
+
+  UndoManager.prototype.clearUndo = function () {
+    this._stack.length = this.length = this.position;
+  };
+
+  UndoManager.prototype.clearRedo = function () {
+    this._stack.splice(0, this.position);
+    this.position = 0;
+    this.length = this._stack.length;
+  };
 
   return UndoManager;
 });
+

--- a/src/undo-manager.js
+++ b/src/undo-manager.js
@@ -1,84 +1,84 @@
 define(function () {
-	'use strict';
+  'use strict';
 
-	function UndoManager(limit, undoScopeHost) {
-		var stack = [];
-		var fireEvent = typeof CustomEvent != 'undefined' && undoScopeHost && undoScopeHost.dispatchEvent;
+  function UndoManager(limit, undoScopeHost) {
+    var stack = [];
+    var fireEvent = typeof CustomEvent != 'undefined' && undoScopeHost && undoScopeHost.dispatchEvent;
 
-		this.position = 0;
-		this.length = 0;
+    this.position = 0;
+    this.length = 0;
 
-		this.transact = function (transaction, merge) {
-			if (arguments.length < 2) {
-				throw new TypeError('Not enough arguments to UndoManager.transact.');
-			}
+    this.transact = function (transaction, merge) {
+      if (arguments.length < 2) {
+        throw new TypeError('Not enough arguments to UndoManager.transact.');
+      }
 
-			transaction.execute();
+      transaction.execute();
 
-			stack.splice(0, this.position);
-			if (merge && this.length) {
-				stack[0].push(transaction);
-			}
-			else {
-				stack.unshift([transaction]);
-			}
-			this.position = 0;
+      stack.splice(0, this.position);
+      if (merge && this.length) {
+        stack[0].push(transaction);
+      }
+      else {
+        stack.unshift([transaction]);
+      }
+      this.position = 0;
 
-			if (limit && stack.length > limit) {
-				this.length = stack.length = limit;
-			}
-			else {
-				this.length = stack.length;
-			}
+      if (limit && stack.length > limit) {
+        this.length = stack.length = limit;
+      }
+      else {
+        this.length = stack.length;
+      }
 
-			if (fireEvent) {
-				undoScopeHost.dispatchEvent(new CustomEvent('DOMTransaction', {detail: {transactions: stack[0].slice()}, bubbles: true, cancelable: false}));
-			}
-		};
+      if (fireEvent) {
+        undoScopeHost.dispatchEvent(new CustomEvent('DOMTransaction', {detail: {transactions: stack[0].slice()}, bubbles: true, cancelable: false}));
+      }
+    };
 
-		this.undo = function () {
-			if (this.position < this.length) {
-				for (var i = stack[this.position].length - 1; i >= 0; i--) {
-					stack[this.position][i].undo();
-				}
-				this.position++;
+    this.undo = function () {
+      if (this.position < this.length) {
+        for (var i = stack[this.position].length - 1; i >= 0; i--) {
+          stack[this.position][i].undo();
+        }
+        this.position++;
 
-				if (fireEvent) {
-					undoScopeHost.dispatchEvent(new CustomEvent('undo', {detail: {transactions: stack[this.position - 1].slice()}, bubbles: true, cancelable: false}));
-				}
-			}
-		};
+        if (fireEvent) {
+          undoScopeHost.dispatchEvent(new CustomEvent('undo', {detail: {transactions: stack[this.position - 1].slice()}, bubbles: true, cancelable: false}));
+        }
+      }
+    };
 
-		this.redo = function () {
-			if (this.position > 0) {
-				for (var i = 0, n = stack[this.position - 1].length; i < n; i++) {
-					stack[this.position - 1][i].redo();
-				}
-				this.position--;
+    this.redo = function () {
+      if (this.position > 0) {
+        for (var i = 0, n = stack[this.position - 1].length; i < n; i++) {
+          stack[this.position - 1][i].redo();
+        }
+        this.position--;
 
-				if (fireEvent) {
-					undoScopeHost.dispatchEvent(new CustomEvent('redo', {detail: {transactions: stack[this.position].slice()}, bubbles: true, cancelable: false}));
-				}
-			}
-		};
+        if (fireEvent) {
+          undoScopeHost.dispatchEvent(new CustomEvent('redo', {detail: {transactions: stack[this.position].slice()}, bubbles: true, cancelable: false}));
+        }
+      }
+    };
 
-		this.item = function (index) {
-			if (index >= 0 && index < this.length) {
-				return stack[index].slice();
-			}
-			return null;
-		};
+    this.item = function (index) {
+      if (index >= 0 && index < this.length) {
+        return stack[index].slice();
+      }
+      return null;
+    };
 
-		this.clearUndo = function () {
-			stack.length = this.length = this.position;
-		};
+    this.clearUndo = function () {
+      stack.length = this.length = this.position;
+    };
 
-		this.clearRedo = function () {
-			stack.splice(0, this.position);
-			this.position = 0;
-			this.length = stack.length;
-		};
-	}
+    this.clearRedo = function () {
+      stack.splice(0, this.position);
+      this.position = 0;
+      this.length = stack.length;
+    };
+  }
 
-	return UndoManager;
+  return UndoManager;
 });

--- a/src/undo-manager.js
+++ b/src/undo-manager.js
@@ -1,43 +1,73 @@
 define(function () {
+	'use strict';
 
-  'use strict';
+	function UndoManager(limit, undoScopeHost) {
+		var stack = [];
+		var fireEvent = typeof CustomEvent != 'undefined' && undoScopeHost && undoScopeHost.dispatchEvent;
 
-  return function (scribe) {
+		this.position = 0;
+		this.length = 0;
 
-    function UndoManager() {
-      this.position = -1;
-      this.stack = [];
-      this.debug = scribe.isDebugModeEnabled();
-    }
+		this.transact = function (transaction, merge) {
+			if (arguments.length < 2)
+				throw new TypeError('Not enough arguments to UndoManager.transact.');
 
-    UndoManager.prototype.maxStackSize = 100;
+			transaction.execute();
 
-    UndoManager.prototype.push = function (item) {
-      if (this.debug) {
-        console.log('UndoManager.push: %s', item);
-      }
-      this.stack.length = ++this.position;
-      this.stack.push(item);
+			stack.splice(0, this.position);
+			if (merge && this.length)
+				stack[0].push(transaction);
+			else
+				stack.unshift([transaction]);
+			this.position = 0;
 
-      while (this.stack.length > this.maxStackSize) {
-        this.stack.shift();
-        --this.position;
-      }
-    };
+			if (limit && stack.length > limit)
+				this.length = stack.length = limit;
+			else
+				this.length = stack.length;
 
-    UndoManager.prototype.undo = function () {
-      if (this.position > 0) {
-        return this.stack[--this.position];
-      }
-    };
+			if (fireEvent)
+				undoScopeHost.dispatchEvent(new CustomEvent('DOMTransaction', {detail: {transactions: stack[0].slice()}, bubbles: true, cancelable: false}));
+		};
 
-    UndoManager.prototype.redo = function () {
-      if (this.position < (this.stack.length - 1)) {
-        return this.stack[++this.position];
-      }
-    };
+		this.undo = function () {
+			if (this.position < this.length) {
+				for (var i = stack[this.position].length - 1; i >= 0; i--)
+					stack[this.position][i].undo();
+				this.position++;
 
-    return UndoManager;
-  };
+				if (fireEvent)
+					undoScopeHost.dispatchEvent(new CustomEvent('undo', {detail: {transactions: stack[this.position - 1].slice()}, bubbles: true, cancelable: false}));
+			}
+		};
 
+		this.redo = function () {
+			if (this.position > 0) {
+				for (var i = 0, n = stack[this.position - 1].length; i < n; i++)
+					stack[this.position - 1][i].redo();
+				this.position--;
+
+				if (fireEvent)
+					undoScopeHost.dispatchEvent(new CustomEvent('redo', {detail: {transactions: stack[this.position].slice()}, bubbles: true, cancelable: false}));
+			}
+		};
+
+		this.item = function (index) {
+			if (index >= 0 && index < this.length)
+				return stack[index].slice();
+			return null;
+		};
+
+		this.clearUndo = function () {
+			stack.length = this.length = this.position;
+		};
+
+		this.clearRedo = function () {
+			stack.splice(0, this.position);
+			this.position = 0;
+			this.length = stack.length;
+		};
+	}
+
+	return UndoManager;
 });

--- a/test/undo-manager.spec.js
+++ b/test/undo-manager.spec.js
@@ -7,7 +7,7 @@ var when = helpers.when;
 var givenContentOf = helpers.givenContentOf;
 var executeCommand = helpers.executeCommand;
 var insertCaretPositionMarker = helpers.insertCaretPositionMarker;
-var initializeScribe = helpers.initializeScribe.bind(null, '../../src/scribe');
+var initializeScribe = helpers.initializeScribe.bind(null, '../../src/scribe', {undo: {enabled: true, limit: 100, interval: 0}});
 
 // Get new referenceS each time a new instance is created
 var driver;


### PR DESCRIPTION
This pull request implements #334, and provides a form of improvement for the undo manager behavior as suggested in #335:

1. Replaces the current undo manager with a new undo manager. The new undo manager follows the W3C UndoManager specifications, and is more flexible than the current one. See: https://github.com/aaalsaleh/undo-manager
2. Updates the way transactions are pushed into the new undo manager.
3. Adds an `interval` option for the undo manager. Now, consecutive transactions within `interval` will be merged as a single transaction (#335).
4. ~~Adds a new `setUndoManager` API for replacing the internal undo manager with external undo manager (#334).~~
5. Several other tiny updates over the undo/redo core commands, and core/patch events. These are needed for the new undo manager.

Please note that point 2 and 3 can be further improved and optimized specifically for Scribe. For example, ~~transactions content can be replaced instead of merged to save space~~ (done!). Also, merging condition can be improved to take other factors into account.
