### PR TITLE
  UndoManager Improvements (Firefox Freezing Fix)

### DIFF
--- a/test/undo-manager.spec.js
+++ b/test/undo-manager.spec.js
@@ -7,7 +7,7 @@ var when = helpers.when;
 var givenContentOf = helpers.givenContentOf;
 var executeCommand = helpers.executeCommand;
 var insertCaretPositionMarker = helpers.insertCaretPositionMarker;
-var initializeScribe = helpers.initializeScribe.bind(null, '../../src/scribe', {undo: {enabled: true, limit: 100, interval: 0}});
+var initializeScribe = helpers.initializeScribe.bind(null, '../../src/scribe');
 
 // Get new referenceS each time a new instance is created
 var driver;
@@ -23,6 +23,14 @@ beforeEach(function () {
 describe('undo manager', function () {
   beforeEach(function () {
     return initializeScribe();
+  });
+  
+  // Undo manager merge interval set to 0ms (default is 1000ms).
+  // This will avoid merging instant typing transactions as performed by these automated tests.
+  beforeEach(function () {
+    return driver.executeScript(function () {
+      window.scribe.options.undo.interval = 0;
+    });
   });
 
   givenContentOf('<p>|1</p>', function () {


### PR DESCRIPTION
Second attempt of #346.

This PR only address the failing test by avoiding passing options to scribe in the test file `undo-manager.spec.js`. Passing options in the tests is known to cause freezing, then a timeout, which end up failing the test. Now, the interval is not passed as an option. Instead, it is changed before starting the tests. It was successfully tested on Firefox 31 on Mac OS X (10.10).

Hopefully it will pass all other browsers/platforms this time around.

Edit: ~~I've just tested it on Firefox 32, and I think there is still freezing issue. I'll try to identify the source of the issue.~~ Actually not only `aaalsaleh/scribe:master` freezes, but also `guardian/scribe:master` freezes on Firefox 32 on Mac OS X (10.10)!