### PR TITLE
Options: break out option handling into its own module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /examples/build.js
 .tern-port
 .npm-debug.log
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+Introduces a new time-based undo manager and improvements to allow multiple Scribe instances to share or have a separate undo manager. Thanks to [Abdulrahman Alsaleh](https://github.com/aaalsaleh) for providing the code and spending a lot of time working with us on the tests.
+
 # 1.2.11
 
 Added configuration for removing `scribe.undoManager`

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "scribe",
   "dependencies": {
-    "lodash-amd": "2.4.1",
+    "lodash-amd": "3.5.0",
     "immutable" : "3.6.2"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "scribe",
   "dependencies": {
-    "lodash-amd": "3.5.0",
+    "lodash-amd": "2.4.1",
     "immutable" : "3.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribe-editor",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "main": "src/scribe.js",
   "dependencies": {
     "lodash-amd": "~2.4.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "main": "src/scribe.js",
   "dependencies": {
-    "lodash-amd": "~3.5.0",
+    "lodash-amd": "~2.4.1",
     "immutable": "~3.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "main": "src/scribe.js",
   "dependencies": {
-    "lodash-amd": "~2.4.1",
+    "lodash-amd": "~3.5.0",
     "immutable": "~3.6.2"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 define(['lodash-amd/modern/objects/defaults',], function (defaults) {
 
-	var defaultOptions = {
+    var defaultOptions = {
       allowBlockElements: true,
       debug: false,
       undo: {

--- a/src/config.js
+++ b/src/config.js
@@ -20,14 +20,14 @@ define(['lodash-amd/modern/objects/defaults',], function (defaults) {
     };
 
 
-	function checkOptions(userSuppliedOptions) {
-		var options = userSuppliedOptions || {};
+    function checkOptions(userSuppliedOptions) {
+        var options = userSuppliedOptions || {};
 
-		return Object.freeze(defaults(options, defaultOptions));
-	}
+        return Object.freeze(defaults(options, defaultOptions));
+    }
 
-	return {
-		defaultOptions: defaultOptions,
-		checkOptions: checkOptions
-	}
+    return {
+        defaultOptions: defaultOptions,
+        checkOptions: checkOptions
+    }
 });

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,33 @@
+define(['lodash-amd/modern/objects/defaults',], function (defaults) {
+
+	var defaultOptions = {
+      allowBlockElements: true,
+      debug: false,
+      undo: {
+        manager: false,
+        enabled: true,
+        limit: 100,
+        interval: 250
+      },
+      defaultCommandPatches: [
+        'bold',
+        'indent',
+        'insertHTML',
+        'insertList',
+        'outdent',
+        'createLink'
+      ]
+    };
+
+
+	function checkOptions(userSuppliedOptions) {
+		var options = userSuppliedOptions || {};
+
+		return Object.freeze(defaults(options, defaultOptions));
+	}
+
+	return {
+		defaultOptions: defaultOptions,
+		checkOptions: checkOptions
+	}
+});

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ define(['lodash-amd/modern/objects/defaults',], function (defaults) {
   function checkOptions(userSuppliedOptions) {
     var options = userSuppliedOptions || {};
 
-    return Object.freeze(defaults(options, defaultOptions));
+    return defaults(options, defaultOptions);
   }
 
   return {

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ define(['lodash-amd/modern/objects/defaults',], function (defaults) {
   function checkOptions(userSuppliedOptions) {
     var options = userSuppliedOptions || {};
 
-    return defaults(options, defaultOptions);
+    return Object.freeze(defaults(options, defaultOptions));
   }
 
   return {

--- a/src/config.js
+++ b/src/config.js
@@ -1,33 +1,33 @@
 define(['lodash-amd/modern/objects/defaults',], function (defaults) {
 
-    var defaultOptions = {
-      allowBlockElements: true,
-      debug: false,
-      undo: {
-        manager: false,
-        enabled: true,
-        limit: 100,
-        interval: 250
-      },
-      defaultCommandPatches: [
-        'bold',
-        'indent',
-        'insertHTML',
-        'insertList',
-        'outdent',
-        'createLink'
-      ]
-    };
+  var defaultOptions = {
+    allowBlockElements: true,
+    debug: false,
+    undo: {
+      manager: false,
+      enabled: true,
+      limit: 100,
+      interval: 250
+    },
+    defaultCommandPatches: [
+      'bold',
+      'indent',
+      'insertHTML',
+      'insertList',
+      'outdent',
+      'createLink'
+    ]
+  };
 
 
-    function checkOptions(userSuppliedOptions) {
-        var options = userSuppliedOptions || {};
+  function checkOptions(userSuppliedOptions) {
+    var options = userSuppliedOptions || {};
 
-        return Object.freeze(defaults(options, defaultOptions));
-    }
+    return Object.freeze(defaults(options, defaultOptions));
+  }
 
-    return {
-        defaultOptions: defaultOptions,
-        checkOptions: checkOptions
-    }
+  return {
+    defaultOptions: defaultOptions,
+    checkOptions: checkOptions
+  }
 });

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -1,5 +1,4 @@
 define([
-  'lodash-amd/modern/objects/defaults',
   './plugins/core/commands',
   './plugins/core/events',
   './plugins/core/formatters/html/replace-nbsp-chars',
@@ -15,9 +14,9 @@ define([
   './event-emitter',
   './element',
   './node',
-  'immutable/dist/immutable'
+  'immutable/dist/immutable',
+  './config'
 ], function (
-  defaults,
   commands,
   events,
   replaceNbspCharsFormatter,
@@ -33,7 +32,8 @@ define([
   EventEmitter,
   elementHelpers,
   nodeHelpers,
-  Immutable
+  Immutable,
+  config
 ) {
 
   'use strict';
@@ -44,26 +44,7 @@ define([
     this.el = el;
     this.commands = {};
 
-    var defaultOptions = {
-      allowBlockElements: true,
-      debug: false,
-      undo: {
-        manager: false,
-        enabled: true,
-        limit: 100,
-        interval: 250
-      },
-      defaultCommandPatches: [
-        'bold',
-        'indent',
-        'insertHTML',
-        'insertList',
-        'outdent',
-        'createLink'
-      ]
-    };
-
-    this.options = Object.freeze(defaults(options || {}, defaultOptions));
+    this.options = config.checkOptions(options);
 
     this.commandPatches = {};
     this._plainTextFormatterFactory = new FormatterFactory();

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -44,7 +44,7 @@ define([
     this.el = el;
     this.commands = {};
 
-    this.options = defaults(options || {}, {
+    var defaultOptions = {
       allowBlockElements: true,
       debug: false,
       undo: {
@@ -61,7 +61,9 @@ define([
         'outdent',
         'createLink'
       ]
-    });
+    };
+
+    this.options = Object.freeze(defaults(options || {}, defaultOptions));
 
     this.commandPatches = {};
     this._plainTextFormatterFactory = new FormatterFactory();

--- a/test/runner.js
+++ b/test/runner.js
@@ -17,7 +17,7 @@ var mocha = new Mocha();
 /**
  * Wait for the connection to Sauce Labs to finish.
  */
-mocha.timeout(10 * 1000);
+mocha.timeout(15 * 1000);
 mocha.reporter('spec');
 mocha.addFile(__dirname + '/block-mode.spec.js');
 mocha.addFile(__dirname + '/commands.spec.js');

--- a/test/runner.js
+++ b/test/runner.js
@@ -17,7 +17,7 @@ var mocha = new Mocha();
 /**
  * Wait for the connection to Sauce Labs to finish.
  */
-mocha.timeout(5 * 1000);
+mocha.timeout(10 * 1000);
 mocha.reporter('spec');
 mocha.addFile(__dirname + '/block-mode.spec.js');
 mocha.addFile(__dirname + '/commands.spec.js');

--- a/test/runner.js
+++ b/test/runner.js
@@ -19,6 +19,12 @@ var mocha = new Mocha();
  */
 mocha.timeout(15 * 1000);
 mocha.reporter('spec');
+
+// Unit tests
+mocha.addFile(__dirname + '/unit/event-emitter.spec.js');
+mocha.addFile(__dirname + '/unit/config.spec.js');
+
+// Browser tests
 mocha.addFile(__dirname + '/block-mode.spec.js');
 mocha.addFile(__dirname + '/commands.spec.js');
 mocha.addFile(__dirname + '/formatters.spec.js');
@@ -26,7 +32,6 @@ mocha.addFile(__dirname + '/inline-elements-mode.spec.js');
 mocha.addFile(__dirname + '/patches.spec.js');
 mocha.addFile(__dirname + '/undo-manager.spec.js');
 mocha.addFile(__dirname + '/selection.spec.js');
-mocha.addFile(__dirname + '/unit/event-emitter.spec.js');
-mocha.addFile(__dirname + '/unit/config.spec.js');
+
 
 createRunner(mocha);

--- a/test/runner.js
+++ b/test/runner.js
@@ -17,7 +17,7 @@ var mocha = new Mocha();
 /**
  * Wait for the connection to Sauce Labs to finish.
  */
-mocha.timeout(15 * 1000);
+mocha.timeout(5 * 1000);
 mocha.reporter('spec');
 mocha.addFile(__dirname + '/block-mode.spec.js');
 mocha.addFile(__dirname + '/commands.spec.js');
@@ -27,5 +27,6 @@ mocha.addFile(__dirname + '/patches.spec.js');
 mocha.addFile(__dirname + '/undo-manager.spec.js');
 mocha.addFile(__dirname + '/selection.spec.js');
 mocha.addFile(__dirname + '/unit/event-emitter.spec.js');
+mocha.addFile(__dirname + '/unit/config.spec.js');
 
 createRunner(mocha);

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -12,21 +12,21 @@ var chai = require('chai');
 var expect = chai.expect;
 
 describe('config', function(){
-	it('should normalise unspecified options', function() {
-		expect(config.checkOptions(undefined)).to.exist;
-	});
+  it('should normalise unspecified options', function() {
+    expect(config.checkOptions(undefined)).to.exist;
+  });
 
-	it('should respect overridden options', function() {
-		var checkedOptions = config.checkOptions({allowBlockElements: false});
+  it('should respect overridden options', function() {
+    var checkedOptions = config.checkOptions({allowBlockElements: false});
 
-		expect(checkedOptions.allowBlockElements).to.be.false;
-	});
+    expect(checkedOptions.allowBlockElements).to.be.false;
+  });
 
-	describe('defaults', function() {
-		it('should apply default values', function() {
-			var checkedOptions = config.checkOptions({});
+  describe('defaults', function() {
+    it('should apply default values', function() {
+      var checkedOptions = config.checkOptions({});
 
-			expect(checkedOptions.allowBlockElements).to.be.true;
-		});
-	});
+      expect(checkedOptions.allowBlockElements).to.be.true;
+    });
+  });
 });

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -1,0 +1,32 @@
+require('node-amd-require')({
+  baseUrl: __dirname,
+  paths: {
+    'lodash-amd': '../../bower_components/lodash-amd',
+    'immutable': '../../bower_components/immutable'
+  }
+});
+
+var config = require('../../src/config');
+
+var chai = require('chai');
+var expect = chai.expect;
+
+describe('config', function(){
+	it('should normalise unspecified options', function() {
+		expect(config.checkOptions(undefined)).to.exist;
+	});
+
+	it('should respect overridden options', function() {
+		var checkedOptions = config.checkOptions({allowBlockElements: false});
+
+		expect(checkedOptions.allowBlockElements).to.be.false;
+	});
+
+	describe('defaults', function() {
+		it('should apply default values', function() {
+			var checkedOptions = config.checkOptions({});
+
+			expect(checkedOptions.allowBlockElements).to.be.true;
+		});
+	});
+});


### PR DESCRIPTION
With the addition of more options I thought it was worth breaking the option handling out to its own module which will also store the default option values. This module has its own unit-tests so that the functionality isn't being tested indirectly via things like the block handling tests.
