### PR TITLE
Added a null check in selection.js

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -24,7 +24,7 @@ function (elementHelper) {
       }
 
       this.selection = rootDoc.getSelection();
-      if (this.selection.rangeCount) {
+      if (this.selection.rangeCount && this.selection.anchorNode) {
         // create the range to avoid chrome bug from getRangeAt / window.getSelection()
         // https://code.google.com/p/chromium/issues/detail?id=380690
         this.range = document.createRange();


### PR DESCRIPTION
I'm running into a case in Shadow DOM where selection.anchorNode and selection.focusNode is null in Chrome, causing the following error in the console log every time the contenteditable div is selected:

Uncaught NotFoundError: Failed to execute 'setStart' on 'Range': The node provided was null

I can't figure out what is causing these nodes to be null and it doesn't seem to affect scribes functionality, so I just added an additional null check.