### PR TITLE
Dependencies: upgrade Lodash to 3.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "scribe",
   "dependencies": {
-    "lodash-amd": "2.4.1",
+    "lodash-amd": "3.5.0",
     "immutable" : "3.6.2"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "scribe",
   "dependencies": {
-    "lodash-amd": "3.5.0",
+    "lodash-compat": "3.5.0-amd",
     "immutable" : "3.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.2",
   "main": "src/scribe.js",
   "dependencies": {
-    "lodash-amd": "~2.4.1",
+    "lodash-amd": "~3.5.0",
     "immutable": "~3.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Our current version of Lodash is quite old so this is partly a hygiene update but also it might address #362