### PR TITLE
Dependencies: update Lodash to 3.5.0 (properly this time)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "scribe",
   "dependencies": {
-    "lodash-amd": "2.4.1",
+    "lodash-amd": "3.5.0",
     "immutable" : "3.6.2"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 define([
-  'lodash-amd/modern/objects/defaults'
+  'lodash-amd/modern/object/defaults'
 ], function (defaults) {
 
   var blockModePlugins = [

--- a/src/dom-observer.js
+++ b/src/dom-observer.js
@@ -1,6 +1,6 @@
 define([
-  'lodash-amd/modern/arrays/flatten',
-  'lodash-amd/modern/collections/toArray',
+  'lodash-amd/modern/array/flatten',
+  'lodash-amd/modern/lang/toArray',
   './element',
   './node'
 ], function (
@@ -26,7 +26,7 @@ define([
     }
 
     var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
-    
+
     // Flag to avoid running recursively
     var runningPostMutation = false;
 

--- a/src/element.js
+++ b/src/element.js
@@ -1,4 +1,4 @@
-define(['lodash-amd/modern/collections/contains'], function (contains) {
+define(['lodash-amd/modern/collection/contains'], function (contains) {
 
   'use strict';
 

--- a/src/event-emitter.js
+++ b/src/event-emitter.js
@@ -1,4 +1,4 @@
-define(['lodash-amd/modern/arrays/pull',
+define(['lodash-amd/modern/array/pull',
   'immutable/dist/immutable'], function (pull, Immutable) {
 
   'use strict';

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -1,5 +1,5 @@
 define([
-  'lodash-amd/modern/collections/contains',
+  'lodash-amd/modern/collection/contains',
   '../../dom-observer'
 ], function (
   contains,

--- a/src/plugins/core/formatters/html/enforce-p-elements.js
+++ b/src/plugins/core/formatters/html/enforce-p-elements.js
@@ -1,5 +1,5 @@
 define([
-  'lodash-amd/modern/arrays/last'
+  'lodash-amd/modern/array/last'
 ], function (
   last
 ) {

--- a/src/plugins/core/formatters/html/ensure-selectable-containers.js
+++ b/src/plugins/core/formatters/html/ensure-selectable-containers.js
@@ -1,6 +1,6 @@
 define([
     '../../../../element',
-    'lodash-amd/modern/collections/contains'
+    'lodash-amd/modern/collection/contains'
   ], function (
     element,
     contains

--- a/src/plugins/core/formatters/plain-text/escape-html-characters.js
+++ b/src/plugins/core/formatters/plain-text/escape-html-characters.js
@@ -1,5 +1,5 @@
 define([
-  'lodash-amd/modern/utilities/escape'
+  'lodash-amd/modern/string/escape'
 ], function (
   escape
 ) {

--- a/src/transaction-manager.js
+++ b/src/transaction-manager.js
@@ -1,4 +1,4 @@
-define(['lodash-amd/modern/objects/assign'], function (assign) {
+define(['lodash-amd/modern/object/assign'], function (assign) {
 
   'use strict';
 


### PR DESCRIPTION
Mirrors the upgrade solution described in #367 

Updates the library and changes the function locations