### PR TITLE
Fix bug in EventEmitter.prototype.off

### DIFF
--- a/src/event-emitter.js
+++ b/src/event-emitter.js
@@ -19,9 +19,9 @@ define(['lodash-amd/modern/array/pull',
   EventEmitter.prototype.off = function (eventName, fn) {
     var listeners = this._listeners[eventName] || Immutable.Set();
     if (fn) {
-      this._listeners = listeners.delete(fn);
+      this._listeners[eventName] = listeners.delete(fn);
     } else {
-      this._listeners = listeners.clear();
+      this._listeners[eventName] = listeners.clear();
     }
   };
 

--- a/test/unit/event-emitter.spec.js
+++ b/test/unit/event-emitter.spec.js
@@ -39,13 +39,37 @@ describe('event-emitter', function(){
 
   });
 
-  it('should remove listeners when off is called', function(){
-    var handle = sinon.spy();
-    emitter.on('event', handle);
-    emitter.trigger('event');
-    emitter.off('event', handle);
+  it('should remove a specific listener when off is called', function(){
+    var handleOne = sinon.spy();
+    var handleTwo = sinon.spy();
+
+    emitter.on('event', handleOne);
+    emitter.on('event', handleTwo);
+
     emitter.trigger('event');
 
-    expect(handle.callCount).to.equal(1);
-  })
+    emitter.off('event', handleOne);
+
+    emitter.trigger('event');
+
+    expect(handleOne.callCount).to.equal(1);
+    expect(handleTwo.callCount).to.equal(2);
+  });
+
+  it('should remove all listeners when off is called', function(){
+    var handleOne = sinon.spy();
+    var handleTwo = sinon.spy();
+
+    emitter.on('event', handleOne);
+    emitter.on('event', handleTwo);
+
+    emitter.trigger('event');
+
+    emitter.off('event');
+
+    emitter.trigger('event');
+
+    expect(handleOne.callCount).to.equal(1);
+    expect(handleTwo.callCount).to.equal(1);
+  });
 });


### PR DESCRIPTION
The most recent version of this code was accidentally replacing the entire `this._listeners` object.