### PR TITLE
#371 quickfix

### DIFF
--- a/examples/shared-undo-manager.html
+++ b/examples/shared-undo-manager.html
@@ -80,7 +80,7 @@
         else if (undoManager.length > 0 && i == undoManager.length) {
           var item = undoManager.item(i - 1)[0];
           stack.value += '[' + (item.scribe == scribe1 ? 'editor1' : 'editor2');
-					stack.value += ': ' + item.previousItem.content.replace(/<em class="scribe-marker">[^<]*?<\/em>/g, '|') + ']\n';
+          stack.value += ': ' + item.previousItem.content.replace(/<em class="scribe-marker">[^<]*?<\/em>/g, '|') + ']\n';
         }
       }
     }

--- a/examples/shared-undo-manager.html
+++ b/examples/shared-undo-manager.html
@@ -67,7 +67,7 @@
     scribe2.on('content-changed', update);
 
     function update() {
-      output.value = 'Edit 1:\n' + scribe1.getHTML() + '\n\nEdit 2:\n' + scribe2.getHTML();
+      output.value = 'Editor 1:\n' + scribe1.getHTML() + '\n\nEditor 2:\n' + scribe2.getHTML();
       // for debugging
       stack.value = '';
       for (var i = 0; i <= undoManager.length; i++) {
@@ -75,12 +75,12 @@
         if (i < undoManager.length) {
           var item = undoManager.item(i)[0];
           stack.value += '[' + (item.scribe == scribe1 ? 'editor1' : 'editor2');
-          stack.value += ': ' + item.content.replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '|') + ']\n';
+          stack.value += ': ' + item.content.replace(/<em class="scribe-marker">[^<]*?<\/em>/g, '|') + ']\n';
         }
-        else if (i == undoManager.length) {
+        else if (undoManager.length > 0 && i == undoManager.length) {
           var item = undoManager.item(i - 1)[0];
           stack.value += '[' + (item.scribe == scribe1 ? 'editor1' : 'editor2');
-          stack.value += ': ' + item.previousItem.content.replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '|') + ']\n';
+					stack.value += ': ' + item.previousItem.content.replace(/<em class="scribe-marker">[^<]*?<\/em>/g, '|') + ']\n';
         }
       }
     }

--- a/setup.sh
+++ b/setup.sh
@@ -4,10 +4,8 @@ npm install
 bower install
 
 # Download the selenium JAR
-SELENIUM_VERSION=2.45.0
-SELENIUM_MINOR_VERSION=2.45
+SELENIUM_VERSION=2.41.0
+SELENIUM_MINOR_VERSION=2.41
 mkdir -p vendor
 wget -O vendor/selenium-server-standalone-$SELENIUM_VERSION.jar \
-  https://selenium-release.storage.googleapis.com/$SELENIUM_MINOR_VERSION/selenium-server-standalone-$SELENIUM_VERSION.jar || \
-  curl -o vendor/selenium-server-standalone-$SELENIUM_VERSION.jar \
   https://selenium-release.storage.googleapis.com/$SELENIUM_MINOR_VERSION/selenium-server-standalone-$SELENIUM_VERSION.jar

--- a/setup.sh
+++ b/setup.sh
@@ -4,8 +4,10 @@ npm install
 bower install
 
 # Download the selenium JAR
-SELENIUM_VERSION=2.41.0
-SELENIUM_MINOR_VERSION=2.41
+SELENIUM_VERSION=2.45.0
+SELENIUM_MINOR_VERSION=2.45
 mkdir -p vendor
 wget -O vendor/selenium-server-standalone-$SELENIUM_VERSION.jar \
+  https://selenium-release.storage.googleapis.com/$SELENIUM_MINOR_VERSION/selenium-server-standalone-$SELENIUM_VERSION.jar || \
+  curl -o vendor/selenium-server-standalone-$SELENIUM_VERSION.jar \
   https://selenium-release.storage.googleapis.com/$SELENIUM_MINOR_VERSION/selenium-server-standalone-$SELENIUM_VERSION.jar

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -92,7 +92,7 @@ define([
     // Formatters
     var defaultFormatters = Immutable.List(this.options.defaultFormatters)
     .filter(function (formatter) { return !!formatters[formatter]; })
-    .map(function (formatter) { return formatters[formatter]; })
+    .map(function (formatter) { return formatters[formatter]; });
 
     // Patches
 
@@ -170,8 +170,7 @@ define([
 
     if (scribe.options.undo.enabled) {
       // Get scribe previous content, and strip markers.
-      var lastContentNoMarkers = scribe._lastItem.content
-        .replace(/<em class="scribe-marker">/g, '').replace(/<\/em>/g, '');
+      var lastContentNoMarkers = scribe._lastItem.content.replace(/<em class="scribe-marker">[^<]*?<\/em>/g, '');
 
       // We only want to push the history if the content actually changed.
       if (scribe.getHTML() !== lastContentNoMarkers) {

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -73,6 +73,28 @@ describe('commands', function () {
         });
       });
     });
+
+    givenContentOf('<p><em>1</em>2|</p>', function () {
+      when('the command is executed', function () {
+        beforeEach(function () {
+          scribeNode.click();
+
+          return executeCommand('bold');
+        });
+
+        when('the user types', function () {
+          beforeEach(function () {
+            return scribeNode.sendKeys('3');
+          });
+
+          it('should make the next text bold', function () {
+            return scribeNode.getInnerHTML().then(function (innerHTML) {
+              expect(innerHTML).to.have.html('<p><em>1</em>2<b>3</b></p>');
+            });
+          });
+        });
+      });
+    });
   });
 
   describe('italic', function () {


### PR DESCRIPTION
This is a quickfix for #371. The replacement of markers using regex is generally not good, and it was there before the move to the new undo manager (unlike what is mentioned in the issue). I've only fixed it by adjusting the regex to only remove the markers `em`s.