### PR TITLE
Testing: discover spec files rather than specifying them

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "plumber-requirejs": "~0.4.0",
     "plumber-uglifyjs": "~0.4.0",
     "plumber-write": "~0.4.0",
-    "q": "~1.0.0",
+    "q": "~1.2",
     "request": "~2.33.0",
-    "scribe-test-harness": "~0.0.20",
+    "scribe-test-harness": "~0.0.21",
     "selenium-webdriver": "~2.41.0",
     "sinon": "^1.12.2"
   },

--- a/test/runner.js
+++ b/test/runner.js
@@ -11,6 +11,7 @@
 
 var Mocha = require('mocha');
 var createRunner = require('scribe-test-harness/create-runner');
+var testEnvironment = require('scribe-test-harness/environment');
 
 var mocha = new Mocha();
 
@@ -20,18 +21,7 @@ var mocha = new Mocha();
 mocha.timeout(15 * 1000);
 mocha.reporter('spec');
 
-// Unit tests
-mocha.addFile(__dirname + '/unit/event-emitter.spec.js');
-mocha.addFile(__dirname + '/unit/config.spec.js');
-
-// Browser tests
-mocha.addFile(__dirname + '/block-mode.spec.js');
-mocha.addFile(__dirname + '/commands.spec.js');
-mocha.addFile(__dirname + '/formatters.spec.js');
-mocha.addFile(__dirname + '/inline-elements-mode.spec.js');
-mocha.addFile(__dirname + '/patches.spec.js');
-mocha.addFile(__dirname + '/undo-manager.spec.js');
-mocha.addFile(__dirname + '/selection.spec.js');
-
-
-createRunner(mocha);
+testEnvironment.loadSpecifications(__dirname + '/**/*.spec.js', mocha)
+  .then(function(mocha) {
+    createRunner(mocha);
+  });


### PR DESCRIPTION
This change should allow people to drop new spec files into the project and have them added to the test runner automatically.