### PR TITLE
Observing 'attributes' is unnecessary

### DIFF
--- a/src/dom-observer.js
+++ b/src/dom-observer.js
@@ -50,7 +50,6 @@ define([
     });
 
     observer.observe(el, {
-      attributes: true,
       childList: true,
       subtree: true
     });


### PR DESCRIPTION
Observing 'attributes' is actually unnecessary since all mutations that don't add or remove DOM nodes are filtered out anyways. See `includeRealMutations`. This will increase performance a bit.