### PR TITLE
Children search: return the root node for empty nodes

### DIFF
--- a/src/api/children.js
+++ b/src/api/children.js
@@ -1,7 +1,11 @@
 define(function () {
 
   'use strict';
-        function getFirstDeepestChild(node) {
+        function firstDeepestChild(node) {
+          if(!node.hasChildNodes()) {
+            return node;
+          }
+
           var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
           var previousNode = treeWalker.currentNode;
           if (treeWalker.firstChild()) {
@@ -18,6 +22,6 @@ define(function () {
         }
 
   return {
-    getFirstDeepestChild: getFirstDeepestChild
+    firstDeepestChild: firstDeepestChild
   }
 });

--- a/src/api/children.js
+++ b/src/api/children.js
@@ -1,0 +1,23 @@
+define(function () {
+
+  'use strict';
+        function getFirstDeepestChild(node) {
+          var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
+          var previousNode = treeWalker.currentNode;
+          if (treeWalker.firstChild()) {
+            // TODO: build list of non-empty elements (used elsewhere)
+            // Do not include non-empty elements
+            if (treeWalker.currentNode.nodeName === 'BR') {
+              return previousNode;
+            } else {
+              return getFirstDeepestChild(treeWalker.currentNode);
+            }
+          } else {
+            return treeWalker.currentNode;
+          }
+        }
+
+  return {
+    getFirstDeepestChild: getFirstDeepestChild
+  }
+});

--- a/src/api/children.js
+++ b/src/api/children.js
@@ -1,25 +1,26 @@
 define(function () {
 
   'use strict';
-        function firstDeepestChild(node) {
-          if(!node.hasChildNodes()) {
-            return node;
-          }
 
-          var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
-          var previousNode = treeWalker.currentNode;
-          if (treeWalker.firstChild()) {
-            // TODO: build list of non-empty elements (used elsewhere)
-            // Do not include non-empty elements
-            if (treeWalker.currentNode.nodeName === 'BR') {
-              return previousNode;
-            } else {
-              return getFirstDeepestChild(treeWalker.currentNode);
-            }
-          } else {
-            return treeWalker.currentNode;
-          }
-        }
+  function firstDeepestChild(node) {
+    if(!node.hasChildNodes()) {
+      return node;
+    }
+
+    var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
+    var previousNode = treeWalker.currentNode;
+    if (treeWalker.firstChild()) {
+      // TODO: build list of non-empty elements (used elsewhere)
+      // Do not include non-empty elements
+      if (treeWalker.currentNode.nodeName === 'BR') {
+        return previousNode;
+      } else {
+        return firstDeepestChild(treeWalker.currentNode);
+      }
+    } else {
+      return treeWalker.currentNode;
+    }
+  }
 
   return {
     firstDeepestChild: firstDeepestChild

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -30,7 +30,7 @@ define([
                   selection.range.startContainer === scribe.el;
 
           if (isFirefoxBug) {
-            var focusElement = children.getFirstDeepestChild(scribe.el.firstChild);
+            var focusElement = children.firstDeepestChild(scribe.el);
 
             var range = selection.range;
 

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -1,9 +1,11 @@
 define([
   'lodash-amd/modern/collection/contains',
-  '../../dom-observer'
+  '../../dom-observer',
+  '../../api/children'
 ], function (
   contains,
-  observeDomChanges
+  observeDomChanges,
+  children
 ) {
 
   'use strict';
@@ -28,7 +30,7 @@ define([
                   selection.range.startContainer === scribe.el;
 
           if (isFirefoxBug) {
-            var focusElement = getFirstDeepestChild(scribe.el.firstChild);
+            var focusElement = children.getFirstDeepestChild(scribe.el.firstChild);
 
             var range = selection.range;
 
@@ -37,22 +39,6 @@ define([
 
             selection.selection.removeAllRanges();
             selection.selection.addRange(range);
-          }
-        }
-
-        function getFirstDeepestChild(node) {
-          var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
-          var previousNode = treeWalker.currentNode;
-          if (treeWalker.firstChild()) {
-            // TODO: build list of non-empty elements (used elsewhere)
-            // Do not include non-empty elements
-            if (treeWalker.currentNode.nodeName === 'BR') {
-              return previousNode;
-            } else {
-              return getFirstDeepestChild(treeWalker.currentNode);
-            }
-          } else {
-            return treeWalker.currentNode;
           }
         }
       }.bind(scribe));

--- a/test/unit/children.spec.js
+++ b/test/unit/children.spec.js
@@ -12,7 +12,7 @@ var chai = require('chai');
 var expect = chai.expect;
 
 describe('children API', function() {
-  it('should return the root node for the empty string', function() {
-    expect(children.getFirstDeepestChild).to.be.a('function');
+  it('should return the root node for node with no children', function() {
+    expect(children.firstDeepestChild).to.be.a('function');
   });
 });

--- a/test/unit/children.spec.js
+++ b/test/unit/children.spec.js
@@ -13,6 +13,7 @@ var expect = chai.expect;
 
 describe('children API', function() {
   it('should return the root node for node with no children', function() {
-    expect(children.firstDeepestChild).to.be.a('function');
+    var fakeNode = {hasChildNodes: function() { return false; }};
+    expect(children.firstDeepestChild(fakeNode)).to.equal(fakeNode);
   });
 });

--- a/test/unit/children.spec.js
+++ b/test/unit/children.spec.js
@@ -1,0 +1,18 @@
+require('node-amd-require')({
+  baseUrl: __dirname,
+  paths: {
+    'lodash-amd': '../../bower_components/lodash-amd',
+    'immutable': '../../bower_components/immutable'
+  }
+});
+
+var children = require('../../src/api/children');
+
+var chai = require('chai');
+var expect = chai.expect;
+
+describe('children API', function() {
+  it('should return the root node for the empty string', function() {
+    expect(children.getFirstDeepestChild).to.be.a('function');
+  });
+});


### PR DESCRIPTION
This is my proposed fix to #368 that builds on the work of #376 but adds a small separation of code and a unit-test for the case that the Scribe content is empty.

I decided not to use a mock browser for the document substitution so this still isn't very testable for genuine tree traversal but it should address people's immediate problems.