### PR TITLE
Micro-optimization: prevent browser relayout when placeMarkers() is called

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -81,8 +81,10 @@ function (elementHelper) {
       if (selectionStartWithinScribeElementStart && selectionEndWithinScribeElementEnd) {
 
         var startMarker = document.createElement('em');
+        startMarker.style.display = 'none';
         startMarker.classList.add('scribe-marker');
         var endMarker = document.createElement('em');
+        endMarker.style.display = 'none';
         endMarker.classList.add('scribe-marker');
 
         // End marker

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -170,7 +170,7 @@ define([
 
     if (scribe.options.undo.enabled) {
       // Get scribe previous content, and strip markers.
-      var lastContentNoMarkers = scribe._lastItem.content.replace(/<em class="scribe-marker">[^<]*?<\/em>/g, '');
+      var lastContentNoMarkers = scribe._lastItem.content.replace(/<em [^>]*class="scribe-marker"[^>]*>[^<]*?<\/em>/g, '');
 
       // We only want to push the history if the content actually changed.
       if (scribe.getHTML() !== lastContentNoMarkers) {


### PR DESCRIPTION
This is a small but meaningful optimization, as placeMarkers() is called in the performance-critical phase while the the user is typing.

Currently `placeMarkers()` forces a browser relayout. However, it doesn't need to since all the code that uses it strictly checks for the presence of the markers and doesn't actually read their element dimensions.

Compare devtools timeline before:
![before](https://cloud.githubusercontent.com/assets/821706/8146589/96eab7c2-11f7-11e5-95cd-c0702777931f.png)

and after:
![after](https://cloud.githubusercontent.com/assets/821706/8146588/96d60854-11f7-11e5-8573-a4332d56524c.png)