### PR TITLE
Faster selection api

### DIFF
--- a/src/api/children.js
+++ b/src/api/children.js
@@ -7,19 +7,12 @@ define(function () {
       return node;
     }
 
-    var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
-    var previousNode = treeWalker.currentNode;
-    if (treeWalker.firstChild()) {
-      // TODO: build list of non-empty elements (used elsewhere)
-      // Do not include non-empty elements
-      if (treeWalker.currentNode.nodeName === 'BR') {
-        return previousNode;
-      } else {
-        return firstDeepestChild(treeWalker.currentNode);
-      }
-    } else {
-      return treeWalker.currentNode;
+    var child = node.firstChild;
+    if( child.nodeName === 'BR' ) {
+      return node;
     }
+
+    return firstDeepestChild(child);
   }
 
   return {

--- a/src/api/children.js
+++ b/src/api/children.js
@@ -7,12 +7,19 @@ define(function () {
       return node;
     }
 
-    var child = node.firstChild;
-    if( child.nodeName === 'BR' ) {
-      return node;
+    var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ALL, null, false);
+    var previousNode = treeWalker.currentNode;
+    if (treeWalker.firstChild()) {
+      // TODO: build list of non-empty elements (used elsewhere)
+      // Do not include non-empty elements
+      if (treeWalker.currentNode.nodeName === 'BR') {
+        return previousNode;
+      } else {
+        return firstDeepestChild(treeWalker.currentNode);
+      }
+    } else {
+      return treeWalker.currentNode;
     }
-
-    return firstDeepestChild(child);
   }
 
   return {

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -104,14 +104,14 @@ define(function () {
       //if this isn't true scribe will place markers within the selections parent
       //we want to ensure that scribe ONLY places markers within it's own element
       if (scribe.el.contains(range.startContainer) && scribe.el.contains(range.endContainer)) {
-        // insert start marker
-        insertMarker(range.cloneRange(), createMarker());
+        // End marker
+        var rangeEnd = range.cloneRange();
+        rangeEnd.collapse(false);
+        insertMarker(rangeEnd, createMarker());
 
         if (! range.collapsed ) {
-          // End marker
-          var rangeEnd = range.cloneRange();
-          rangeEnd.collapse(false);
-          insertMarker(rangeEnd, createMarker());
+          // insert start marker
+          insertMarker(range.cloneRange(), createMarker());
         }
 
         this.selection.removeAllRanges();

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -36,7 +36,6 @@ define(function () {
        * node (`removeFormat`, `unlink`).
        * As per: http://jsbin.com/hajim/5/edit?js,console,output
        */
-      // TODO: abstract into polyfill for `Range.insertNode`
       if (marker.nextSibling && nodeHelper.isEmptyTextNode(marker.nextSibling)) {
         nodeHelper.removeNode(marker.nextSibling);
       }
@@ -64,8 +63,10 @@ define(function () {
         this.range = document.createRange();
 
         // Check if anchorNode is before focusNode, reverse the range if not
-        if( nodeHelper.isBefore(this.selection.anchorNode, this.selection.focusNode)
-          || this.selection.anchorNode === this.selection.focusNode ) {
+        if (this.selection.anchorNode === this.selection.focusNode) {
+          this.range.setStart(this.selection.anchorNode, Math.min(this.selection.anchorOffset, this.selection.focusOffset));
+          this.range.setStart(this.selection.anchorNode, Math.max(this.selection.anchorOffset, this.selection.focusOffset));
+        } else if (nodeHelper.isBefore(this.selection.anchorNode, this.selection.focusNode)) {
           this.range.setStart(this.selection.anchorNode, this.selection.anchorOffset);
           this.range.setEnd(this.selection.focusNode, this.selection.focusOffset);
         } else {

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -105,7 +105,7 @@ define(function () {
       //we want to ensure that scribe ONLY places markers within it's own element
       if (scribe.el.contains(range.startContainer) && scribe.el.contains(range.endContainer)) {
         // insert start marker
-        insertMarker(range, createMarker());
+        insertMarker(range.cloneRange(), createMarker());
 
         if (! range.collapsed ) {
           // End marker

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -65,7 +65,7 @@ define(function () {
         // Check if anchorNode is before focusNode, reverse the range if not
         if (this.selection.anchorNode === this.selection.focusNode) {
           this.range.setStart(this.selection.anchorNode, Math.min(this.selection.anchorOffset, this.selection.focusOffset));
-          this.range.setStart(this.selection.anchorNode, Math.max(this.selection.anchorOffset, this.selection.focusOffset));
+          this.range.setEnd(this.selection.anchorNode, Math.max(this.selection.anchorOffset, this.selection.focusOffset));
         } else if (nodeHelper.isBefore(this.selection.anchorNode, this.selection.focusNode)) {
           this.range.setStart(this.selection.anchorNode, this.selection.anchorOffset);
           this.range.setEnd(this.selection.focusNode, this.selection.focusOffset);

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -21,6 +21,7 @@ define(function () {
 
     function createMarker() {
       var node = document.createElement('em');
+      node.style.display = 'none';
       node.classList.add('scribe-marker');
       return node;
     }

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -104,14 +104,14 @@ define(function () {
       //if this isn't true scribe will place markers within the selections parent
       //we want to ensure that scribe ONLY places markers within it's own element
       if (scribe.el.contains(range.startContainer) && scribe.el.contains(range.endContainer)) {
-        // End marker
-        var rangeEnd = range.cloneRange();
-        rangeEnd.collapse(false);
-        insertMarker(rangeEnd, createMarker());
+        // insert start marker
+        insertMarker(range.cloneRange(), createMarker());
 
         if (! range.collapsed ) {
-          // insert start marker
-          insertMarker(range.cloneRange(), createMarker());
+          // End marker
+          var rangeEnd = range.cloneRange();
+          rangeEnd.collapse(false);
+          insertMarker(rangeEnd, createMarker());
         }
 
         this.selection.removeAllRanges();

--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -1,44 +1,74 @@
-define([
-  '../element'
-],
-function (elementHelper) {
+define(function () {
 
   'use strict';
 
   return function (scribe) {
-    /**
-     * Wrapper for object holding currently selected text.
-     */
-    function Selection() {
-      var rootDoc = document;
+    var rootDoc = scribe.el.ownerDocument;
+    var nodeHelper = scribe.node;
 
-      // find the parent document or document fragment
+    // find the parent document or document fragment
+    if( rootDoc.compareDocumentPosition(scribe.el) & Node.DOCUMENT_POSITION_DISCONNECTED ) {
       var currentElement = scribe.el.parentNode;
-      while(currentElement && currentElement.nodeType !== Node.DOCUMENT_FRAGMENT_NODE && currentElement.nodeType !== Node.DOCUMENT_NODE) {
+      while(currentElement && nodeHelper.isFragment(currentElement)) {
         currentElement = currentElement.parentNode;
       }
 
       // if we found a document fragment and it has a getSelection method, set it to the root doc
-      if (currentElement && currentElement.nodeType === Node.DOCUMENT_FRAGMENT_NODE && currentElement.getSelection) {
+      if (currentElement && currentElement.getSelection) {
         rootDoc = currentElement;
       }
+    }
 
+    function createMarker() {
+      var node = document.createElement('em');
+      node.classList.add('scribe-marker');
+      return node;
+    }
+
+    function insertMarker(range, marker) {
+      range.insertNode(marker);
+
+      /**
+       * Chrome and Firefox: `Range.insertNode` inserts a bogus text node after
+       * the inserted element. We just remove it. This in turn creates several
+       * bugs when perfoming commands on selections that contain an empty text
+       * node (`removeFormat`, `unlink`).
+       * As per: http://jsbin.com/hajim/5/edit?js,console,output
+       */
+      // TODO: abstract into polyfill for `Range.insertNode`
+      if (marker.nextSibling && nodeHelper.isEmptyTextNode(marker.nextSibling)) {
+        nodeHelper.removeNode(marker.nextSibling);
+      }
+
+      /**
+       * Chrome and Firefox: `Range.insertNode` inserts a bogus text node before
+       * the inserted element when the child element is at the start of a block
+       * element. We just remove it.
+       * FIXME: Document why we need to remove this
+       * As per: http://jsbin.com/sifez/1/edit?js,console,output
+       */
+      if (marker.previousSibling && nodeHelper.isEmptyTextNode(marker.previousSibling)) {
+        nodeHelper.removeNode(marker.previousSibling);
+      }
+    }
+
+    /**
+     * Wrapper for object holding currently selected text.
+     */
+    function Selection() {
       this.selection = rootDoc.getSelection();
       if (this.selection.rangeCount && this.selection.anchorNode) {
         // create the range to avoid chrome bug from getRangeAt / window.getSelection()
         // https://code.google.com/p/chromium/issues/detail?id=380690
         this.range = document.createRange();
-        var reverseRange = document.createRange();
 
-        this.range.setStart(this.selection.anchorNode, this.selection.anchorOffset);
-        reverseRange.setStart(this.selection.focusNode, this.selection.focusOffset);
-
-        // Check if anchorNode is before focusNode, use reverseRange if not
-        if (this.range.compareBoundaryPoints(Range.START_TO_START, reverseRange) <= 0) {
+        // Check if anchorNode is before focusNode, reverse the range if not
+        if( nodeHelper.isBefore(this.selection.anchorNode, this.selection.focusNode)
+          || this.selection.anchorNode === this.selection.focusNode ) {
+          this.range.setStart(this.selection.anchorNode, this.selection.anchorOffset);
           this.range.setEnd(this.selection.focusNode, this.selection.focusOffset);
-        }
-        else {
-          this.range = reverseRange;
+        } else {
+          this.range.setStart(this.selection.focusNode, this.selection.focusOffset);
           this.range.setEnd(this.selection.anchorNode, this.selection.anchorOffset);
         }
       }
@@ -52,9 +82,9 @@ function (elementHelper) {
       if (!range) { return; }
 
       var node = new scribe.api.Node(this.range.commonAncestorContainer);
-      var isTopContainerElement = node.node && scribe.el === node.node;
-
-      return ! isTopContainerElement && nodeFilter(node.node) ? node.node : node.getAncestor(scribe.el, nodeFilter);
+      return ! (node.node && scribe.el === node.node) && nodeFilter(node.node) ?
+        node.node :
+        node.getAncestor(scribe.el, nodeFilter);
     };
 
     Selection.prototype.placeMarkers = function () {
@@ -65,140 +95,26 @@ function (elementHelper) {
 
       //we need to ensure that the scribe's element lives within the current document to avoid errors with the range comparison (see below)
       //one way to do this is to check if it's visible (is this the best way?).
-      if (!scribe.el.offsetParent) {
+      if (!document.contains(scribe.el)) {
         return;
       }
 
       //we want to ensure that the current selection is within the current scribe node
       //if this isn't true scribe will place markers within the selections parent
       //we want to ensure that scribe ONLY places markers within it's own element
-      var scribeNodeRange = document.createRange();
-      scribeNodeRange.selectNodeContents(scribe.el);
+      if (scribe.el.contains(range.startContainer) && scribe.el.contains(range.endContainer)) {
+        // insert start marker
+        insertMarker(range, createMarker());
 
-      var selectionStartWithinScribeElementStart = this.range.compareBoundaryPoints(Range.START_TO_START, scribeNodeRange) >= 0;
-      var selectionEndWithinScribeElementEnd = this.range.compareBoundaryPoints(Range.END_TO_END, scribeNodeRange) <= 0;
-
-      if (selectionStartWithinScribeElementStart && selectionEndWithinScribeElementEnd) {
-
-        var startMarker = document.createElement('em');
-        startMarker.style.display = 'none';
-        startMarker.classList.add('scribe-marker');
-        var endMarker = document.createElement('em');
-        endMarker.style.display = 'none';
-        endMarker.classList.add('scribe-marker');
-
-        // End marker
-        var rangeEnd = this.range.cloneRange();
-        rangeEnd.collapse(false);
-        rangeEnd.insertNode(endMarker);
-
-        /**
-         * Chrome and Firefox: `Range.insertNode` inserts a bogus text node after
-         * the inserted element. We just remove it. This in turn creates several
-         * bugs when perfoming commands on selections that contain an empty text
-         * node (`removeFormat`, `unlink`).
-         * As per: http://jsbin.com/hajim/5/edit?js,console,output
-         */
-        // TODO: abstract into polyfill for `Range.insertNode`
-        if (endMarker.nextSibling &&
-            endMarker.nextSibling.nodeType === Node.TEXT_NODE
-            && endMarker.nextSibling.data === '') {
-          endMarker.parentNode.removeChild(endMarker.nextSibling);
+        if (! range.collapsed ) {
+          // End marker
+          var rangeEnd = range.cloneRange();
+          rangeEnd.collapse(false);
+          insertMarker(rangeEnd, createMarker());
         }
-
-
-
-        /**
-         * Chrome and Firefox: `Range.insertNode` inserts a bogus text node before
-         * the inserted element when the child element is at the start of a block
-         * element. We just remove it.
-         * FIXME: Document why we need to remove this
-         * As per: http://jsbin.com/sifez/1/edit?js,console,output
-         */
-        if (endMarker.previousSibling &&
-            endMarker.previousSibling.nodeType === Node.TEXT_NODE
-            && endMarker.previousSibling.data === '') {
-          endMarker.parentNode.removeChild(endMarker.previousSibling);
-        }
-
-
-        /**
-         * This is meant to test Chrome inserting erroneous text blocks into
-         * the scribe el when focus switches from a scribe.el to a button to
-         * the scribe.el. However, this is impossible to simlulate correctly
-         * in a test.
-         *
-         * This behaviour does not happen in Firefox.
-         *
-         * See http://jsbin.com/quhin/2/edit?js,output,console
-         *
-         * To reproduce the bug, follow the following steps:
-         *    1. Select text and create H2
-         *    2. Move cursor to front of text.
-         *    3. Remove the H2 by clicking the button
-         *    4. Observe that you are left with an empty H2
-         *        after the element.
-         *
-         * The problem is caused by the Range being different, depending on
-         * the position of the marker.
-         *
-         * Consider the following two scenarios.
-         *
-         * A)
-         *   1. scribe.el contains: ["1", <em>scribe-marker</em>]
-         *   2. Click button and click the right of to scribe.el
-         *   3. scribe.el contains: ["1", <em>scribe-marker</em>. #text]
-         *
-         *   This is wrong but does not cause the problem.
-         *
-         * B)
-         *   1. scribe.el contains: ["1", <em>scribe-marker</em>]
-         *   2. Click button and click to left of scribe.el
-         *   3. scribe.el contains: [#text, <em>scribe-marker</em>, "1"]
-         *
-         * The second example sets the range in the wrong place, meaning
-         * that in the second case the formatBlock is executed on the wrong
-         * element [the text node] leaving the empty H2 behind.
-         **/
-
-        // using range.collapsed vs selection.isCollapsed - https://code.google.com/p/chromium/issues/detail?id=447523
-        if (! this.range.collapsed) {
-          // Start marker
-          var rangeStart = this.range.cloneRange();
-          rangeStart.collapse(true);
-          rangeStart.insertNode(startMarker);
-
-          /**
-           * Chrome and Firefox: `Range.insertNode` inserts a bogus text node after
-           * the inserted element. We just remove it. This in turn creates several
-           * bugs when perfoming commands on selections that contain an empty text
-           * node (`removeFormat`, `unlink`).
-           * As per: http://jsbin.com/hajim/5/edit?js,console,output
-           */
-          // TODO: abstract into polyfill for `Range.insertNode`
-          if (startMarker.nextSibling &&
-              startMarker.nextSibling.nodeType === Node.TEXT_NODE
-              && startMarker.nextSibling.data === '') {
-            startMarker.parentNode.removeChild(startMarker.nextSibling);
-          }
-
-          /**
-           * Chrome and Firefox: `Range.insertNode` inserts a bogus text node
-           * before the inserted element when the child element is at the start of
-           * a block element. We just remove it.
-           * FIXME: Document why we need to remove this
-           * As per: http://jsbin.com/sifez/1/edit?js,console,output
-           */
-          if (startMarker.previousSibling &&
-              startMarker.previousSibling.nodeType === Node.TEXT_NODE
-              && startMarker.previousSibling.data === '') {
-            startMarker.parentNode.removeChild(startMarker.previousSibling);
-          }
-        }
-
 
         this.selection.removeAllRanges();
-        this.selection.addRange(this.range);
+        this.selection.addRange(range);
       }
     };
 
@@ -207,9 +123,8 @@ function (elementHelper) {
     };
 
     Selection.prototype.removeMarkers = function () {
-      var markers = this.getMarkers();
-      Array.prototype.forEach.call(markers, function (marker) {
-        marker.parentNode.removeChild(marker);
+      Array.prototype.forEach.call(this.getMarkers(), function (marker) {
+        nodeHelper.removeNode(marker);
       });
     };
 
@@ -225,13 +140,9 @@ function (elementHelper) {
       var newRange = document.createRange();
 
       newRange.setStartBefore(markers[0]);
-      if (markers.length >= 2) {
-        newRange.setEndAfter(markers[1]);
-      } else {
-        // We always reset the end marker because otherwise it will just
-        // use the current range’s end marker.
-        newRange.setEndAfter(markers[0]);
-      }
+      // We always reset the end marker because otherwise it will just
+      // use the current range’s end marker.
+      newRange.setEndAfter(markers.length >= 2 ? markers[1] : markers[0]);
 
       if (! keepMarkers) {
         this.removeMarkers();
@@ -242,37 +153,10 @@ function (elementHelper) {
     };
 
     Selection.prototype.isCaretOnNewLine = function () {
-      // return true if nested inline tags ultimately just contain <br> or ""
-      function isEmptyInlineElement(node) {
-
-        var treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT, null, false);
-
-        var currentNode = treeWalker.root;
-
-        while(currentNode) {
-          var numberOfChildren = currentNode.childNodes.length;
-
-          // forks in the tree or text mean no new line
-          if (numberOfChildren > 1 ||
-              (numberOfChildren === 1 && currentNode.textContent.trim() !== ''))
-            return false;
-
-          if (numberOfChildren === 0) {
-            return currentNode.textContent.trim() === '';
-          }
-
-          currentNode = treeWalker.nextNode();
-        };
-      };
-
       var containerPElement = this.getContaining(function (node) {
         return node.nodeName === 'P';
       });
-      if (containerPElement) {
-        return isEmptyInlineElement(containerPElement);
-      } else {
-        return false;
-      }
+      return !! containerPElement && nodeHelper.isEmptyInlineElement(containerPElement);
     };
 
     return Selection;

--- a/src/node.js
+++ b/src/node.js
@@ -5,7 +5,7 @@ define(function () {
   // return true if nested inline tags ultimately just contain <br> or ""
   function isEmptyInlineElement(node) {
     if( node.children.length > 1 ) return false;
-    if( node.children.length === 1 && node.textContent.trim() === '' ) return false;
+    if( node.children.length === 1 && node.textContent.trim() !== '' ) return false;
     if( node.children.length === O ) return node.textContent.trim() === '';
     return isEmptyInlineElement(node.children[0]);
   }

--- a/src/node.js
+++ b/src/node.js
@@ -6,7 +6,7 @@ define(function () {
   function isEmptyInlineElement(node) {
     if( node.children.length > 1 ) return false;
     if( node.children.length === 1 && node.textContent.trim() !== '' ) return false;
-    if( node.children.length === O ) return node.textContent.trim() === '';
+    if( node.children.length === 0 ) return node.textContent.trim() === '';
     return isEmptyInlineElement(node.children[0]);
   }
 

--- a/src/node.js
+++ b/src/node.js
@@ -1,9 +1,29 @@
-define([], function () {
+define(function () {
 
   'use strict';
 
+  // return true if nested inline tags ultimately just contain <br> or ""
+  function isEmptyInlineElement(node) {
+    if( node.children.length > 1 ) return false;
+    if( node.children.length === 1 && node.textContent.trim() === '' ) return false;
+    if( node.children.length === O ) return node.textContent.trim() === '';
+    return isEmptyInlineElement(node.children[0]);
+  }
+
+  function isText(node) {
+    return node.nodeType === Node.TEXT_NODE;
+  }
+
   function isEmptyTextNode(node) {
-    return (node.nodeType === Node.TEXT_NODE && node.textContent === '');
+    return isText(node) && node.data === '';
+  }
+
+  function isFragment(node) {
+    return node.nodeType === Node.DOCUMENT_FRAGMENT_NODE;
+  }
+
+  function isBefore(node1, node2) {
+    return node1.compareDocumentPosition(node2) & Node.DOCUMENT_POSITION_FOLLOWING;
   }
 
   function insertAfter(newNode, referenceNode) {
@@ -15,7 +35,11 @@ define([], function () {
   }
 
   return {
+    isEmptyInlineElement: isEmptyInlineElement,
+    isText: isText,
     isEmptyTextNode: isEmptyTextNode,
+    isFragment: isFragment,
+    isBefore: isBefore,
     insertAfter: insertAfter,
     removeNode: removeNode
   };

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -44,9 +44,6 @@ define([
 
     this.api = new Api(this);
 
-    this.node = nodeHelpers;
-    this.element = elementHelpers;
-
     this.Immutable = Immutable;
 
     var TransactionManager = buildTransactionManager(this);
@@ -127,6 +124,8 @@ define([
   }
 
   Scribe.prototype = Object.create(EventEmitter.prototype);
+  Scribe.prototype.node = nodeHelpers;
+  Scribe.prototype.element = elementHelpers;
 
   // For plugins
   // TODO: tap combinator?


### PR DESCRIPTION
* Removed unnecessary dependency on AMD module `element` (already available in `scribe`)
* Moved the `rootDoc` selection out of the constructor so that it is executed only once (per Scribe instance)
* Used `compareDocumentPosition` to detect if `scribe.el` is in a fragment, and only then look for that fragment
* Moved redundant code in small, optimizable functions `createMaker` and `insertMarker`
* Replaced range arithmetic with simpler node comparisons
* Replaced `Element.offsetParent` test with `document.contains`, more accurate
* Overall simpler `placeMarker` implementation will less transient variables
* Faster implementation of `isEmtpyInlineElement` (moved to node.js for consistency)
* Moved `scribe.node` and `scribe.element` up in the prototype chain so they're assigned at parse time