### PR TITLE
Faster enforce p element

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -14,10 +14,19 @@ define([], function () {
     return node.parentNode.removeChild(node);
   }
 
+  function wrap(nodes, parentNode) {
+    nodes[0].parentNode.insertBefore(parentNode, nodes[0]);
+    nodes.forEach(function (node) {
+      parentNode.appendChild(node);
+    });
+    return parentNode;
+  }
+
   return {
     isEmptyTextNode: isEmptyTextNode,
     insertAfter: insertAfter,
-    removeNode: removeNode
+    removeNode: removeNode,
+    wrap: wrap
   };
 
 });

--- a/src/plugins/core/formatters/html/enforce-p-elements.js
+++ b/src/plugins/core/formatters/html/enforce-p-elements.js
@@ -1,8 +1,6 @@
 define([
-  'lodash-amd/modern/array/last'
-], function (
-  last
-) {
+  'immutable/dist/immutable'
+], function (Immutable) {
 
   /**
    * Chrome and Firefox: Upon pressing backspace inside of a P, the
@@ -21,69 +19,68 @@ define([
 
   'use strict';
 
-  /**
-   * Wrap consecutive inline elements and text nodes in a P element.
-   */
-  function wrapChildNodes(scribe, parentNode) {
-    var groups = Array.prototype.reduce.call(parentNode.childNodes,
-                                             function (accumulator, binChildNode) {
-      var group = last(accumulator);
-      if (! group) {
-        startNewGroup();
-      } else {
-        var isBlockGroup = scribe.element.isBlockElement(group[0]);
-        if (isBlockGroup === scribe.element.isBlockElement(binChildNode)) {
-          group.push(binChildNode);
-        } else {
-          startNewGroup();
-        }
-      }
-
-      return accumulator;
-
-      function startNewGroup() {
-        var newGroup = [binChildNode];
-        accumulator.push(newGroup);
-      }
-    }, []);
-
-    var consecutiveInlineElementsAndTextNodes = groups.filter(function (group) {
-      var isBlockGroup = scribe.element.isBlockElement(group[0]);
-      return ! isBlockGroup;
-    });
-
-    consecutiveInlineElementsAndTextNodes.forEach(function (nodes) {
-      var pElement = document.createElement('p');
-      nodes[0].parentNode.insertBefore(pElement, nodes[0]);
-      nodes.forEach(function (node) {
-        pElement.appendChild(node);
-      });
-    });
-
-    parentNode._isWrapped = true;
-  }
-
-  // Traverse the tree, wrapping child nodes as we go.
-  function traverse(scribe, parentNode) {
-    var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
-    var node = treeWalker.firstChild();
-
-    // FIXME: does this recurse down?
-
-    while (node) {
-      // TODO: At the moment we only support BLOCKQUOTEs. See failing
-      // tests.
-      if (node.nodeName === 'BLOCKQUOTE' && ! node._isWrapped) {
-        wrapChildNodes(scribe, node);
-        traverse(scribe, parentNode);
-        break;
-      }
-      node = treeWalker.nextSibling();
-    }
-  }
-
   return function () {
     return function (scribe) {
+      /**
+       * Wrap consecutive inline elements and text nodes in a P element.
+       */
+      function wrapChildNodes(parentNode) {
+        var groups = Array.prototype.reduce.call(parentNode.childNodes,
+                                                 function (accumulator, binChildNode) {
+          var group = last(accumulator);
+          if (! group) {
+            startNewGroup();
+          } else {
+            var isBlockGroup = scribe.element.isBlockElement(group[0]);
+            if (isBlockGroup === scribe.element.isBlockElement(binChildNode)) {
+              group.push(binChildNode);
+            } else {
+              startNewGroup();
+            }
+          }
+
+          return accumulator;
+
+          function startNewGroup() {
+            var newGroup = [binChildNode];
+            accumulator.push(newGroup);
+          }
+        }, []);
+
+        var consecutiveInlineElementsAndTextNodes = groups.filter(function (group) {
+          var isBlockGroup = scribe.element.isBlockElement(group[0]);
+          return ! isBlockGroup;
+        });
+
+        consecutiveInlineElementsAndTextNodes.forEach(function (nodes) {
+          var pElement = document.createElement('p');
+          nodes[0].parentNode.insertBefore(pElement, nodes[0]);
+          nodes.forEach(function (node) {
+            pElement.appendChild(node);
+          });
+        });
+
+        parentNode._isWrapped = true;
+      }
+
+      // Traverse the tree, wrapping child nodes as we go.
+      function traverse(parentNode) {
+        var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
+        var node = treeWalker.firstChild();
+
+        // FIXME: does this recurse down?
+
+        while (node) {
+          // TODO: At the moment we only support BLOCKQUOTEs. See failing
+          // tests.
+          if (node.nodeName === 'BLOCKQUOTE' && ! node._isWrapped) {
+            wrapChildNodes(node);
+            traverse(parentNode);
+            break;
+          }
+          node = treeWalker.nextSibling();
+        }
+      }
 
       scribe.registerHTMLFormatter('normalize', function (html) {
         /**
@@ -98,8 +95,8 @@ define([
         var bin = document.createElement('div');
         bin.innerHTML = html;
 
-        wrapChildNodes(scribe, bin);
-        traverse(scribe, bin);
+        wrapChildNodes(bin);
+        traverse(bin);
 
         return bin.innerHTML;
       });

--- a/src/plugins/core/formatters/html/enforce-p-elements.js
+++ b/src/plugins/core/formatters/html/enforce-p-elements.js
@@ -1,6 +1,6 @@
 define([
-  'immutable/dist/immutable'
-], function (Immutable) {
+  'lodash-amd/modern/array/last'
+], function (last) {
 
   /**
    * Chrome and Firefox: Upon pressing backspace inside of a P, the
@@ -65,20 +65,12 @@ define([
 
       // Traverse the tree, wrapping child nodes as we go.
       function traverse(parentNode) {
-        var treeWalker = document.createTreeWalker(parentNode, NodeFilter.SHOW_ELEMENT, null, false);
-        var node = treeWalker.firstChild();
+        var i = -1, node;
 
-        // FIXME: does this recurse down?
-
-        while (node) {
-          // TODO: At the moment we only support BLOCKQUOTEs. See failing
-          // tests.
-          if (node.nodeName === 'BLOCKQUOTE' && ! node._isWrapped) {
+        while (node = parentNode.children[++i]) {
+          if( node.tagName === 'BLOCKQUOTE' && ! node._isWrapped ) {
             wrapChildNodes(node);
-            traverse(parentNode);
-            break;
           }
-          node = treeWalker.nextSibling();
         }
       }
 

--- a/src/plugins/core/formatters/html/enforce-p-elements.js
+++ b/src/plugins/core/formatters/html/enforce-p-elements.js
@@ -36,20 +36,19 @@ define([
           .groupBy(function(node, key, list) {
             return key === 0 || node.previousSibling === list.get(key - 1) ?
               index :
-              ++index;
+              index += 1;
           })
           .forEach(function(nodeGroup) {
             nodeHelpers.wrap(nodeGroup.toArray(), document.createElement('p'));
           });
-        parentNode._isWrapped = true;
       }
 
       // Traverse the tree, wrapping child nodes as we go.
       function traverse(parentNode) {
-        var i = -1, node;
+        var i = 0, node;
 
-        while (node = parentNode.children[++i]) {
-          if( node.tagName === 'BLOCKQUOTE' && ! node._isWrapped ) {
+        while (node = parentNode.children[i++]) {
+          if (node.tagName === 'BLOCKQUOTE') {
             wrapChildNodes(node);
           }
         }


### PR DESCRIPTION
* Removed dependency on lodash
* Moved `wrapChildNodes` and `traverse` inside the closure to avoid passing around `scribe`
* Rewrote `traverse` without TreeWalker and recursive calls
* Wrote a more efficient `wrapChildNodes` using immutable data structures