### PR TITLE
Replaced Array.map+slice+reduce+filter with Array.some

### DIFF
--- a/src/dom-observer.js
+++ b/src/dom-observer.js
@@ -14,8 +14,8 @@ define([
 
   function includeRealMutations(mutations) {
     return mutations.some(function(mutation) {
-      return mutations.some.call(mutation.addedNodes, hasRealMutation) ||
-        mutations.some.call(mutation.removedNodes, hasRealMutation);
+      return Array.prototype.some.call(mutation.addedNodes, hasRealMutation) ||
+        Array.prototype.some.call(mutation.removedNodes, hasRealMutation);
     });
   }
 

--- a/src/dom-observer.js
+++ b/src/dom-observer.js
@@ -3,24 +3,23 @@ define([
   './node'
 ], function (elementHelpers, nodeHelpers) {
 
+  var MutationObserver = window.MutationObserver ||
+    window.WebKitMutationObserver ||
+    window.MozMutationObserver;
+
+  function hasRealMutation(n) {
+    return ! nodeHelpers.isEmptyTextNode(n) &&
+      ! elementHelpers.isSelectionMarkerNode(n);
+  }
+
+  function includeRealMutations(mutations) {
+    return mutations.some(function(mutation) {
+      return mutations.some.call(mutation.addedNodes, hasRealMutation) ||
+        mutations.some.call(mutation.removedNodes, hasRealMutation);
+    });
+  }
+
   function observeDomChanges(el, callback) {
-    function includeRealMutations(mutations) {
-      var realChangedNodes = mutations
-      .map(function(mutation) {
-        return mutations.slice.call(mutation.addedNodes)
-          .concat(mutations.slice.call(mutation.removedNodes));
-      })
-      .reduce(function(result, input) { return result.concat(input); }, [])
-      .filter(function(n) {
-        return ! nodeHelpers.isEmptyTextNode(n) &&
-          ! elementHelpers.isSelectionMarkerNode(n);
-      });
-
-      return realChangedNodes.length > 0;
-    }
-
-    var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
-
     // Flag to avoid running recursively
     var runningPostMutation = false;
 


### PR DESCRIPTION
A small change which could potentially yield great results (think cut-and-paste large documents). In `includeRealMutations`, we just want to return as soon as a matching node is found, hence `Array.some`.