### PR TITLE
Paste: Unify clipboard types data types

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -1,9 +1,11 @@
 define([
   '../../dom-observer',
-  '../../api/children'
+  '../../api/children',
+  'immutable'
 ], function (
   observeDomChanges,
-  children
+  children,
+  Immutable
 ) {
 
   'use strict';
@@ -184,7 +186,7 @@ define([
         if (event.clipboardData) {
           event.preventDefault();
 
-          if (event.clipboardData.types.indexOf('text/html') !== -1) {
+          if (Immutable.List(Array.from(event.clipboardData.types)).includes('text/html')) {
             scribe.insertHTML(event.clipboardData.getData('text/html'));
           } else {
             scribe.insertPlainText(event.clipboardData.getData('text/plain'));


### PR DESCRIPTION
Combines @alexygolev 's [advice](https://github.com/guardian/scribe/issues/401#issuecomment-115260565) with my own desire to hit everything with the Immutable hammer.

Should finally solve #401 

An illustration of the unification: https://jsfiddle.net/heopbyo3/3/