### PR TITLE
Catch unexpected error when calling queryCommandState in Firefox

### DIFF
--- a/BROWSERINCONSISTENCIES.md
+++ b/BROWSERINCONSISTENCIES.md
@@ -73,6 +73,9 @@ Playground: http://jsbin.com/iwEWUXo/2/edit?js,console,output
 * `subscript`: Firefox: Returns false when a whole `SUB` is selected:
   http://jsbin.com/marox/1/edit?js,console,output
   - True for all inline elements?
+* Firefox throws `NS_ERROR_UNEXPECTED` error for `insertUnorderedList` and
+  `insertOrderedList` when a contenteditable is not focussed, see:
+  https://github.com/guardian/scribe/issues/208
 
 ### `Element.focus`
 * Firefox: Giving focus to a `contenteditable` will place the caret outside of

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,7 +6,7 @@ export TEST_SERVER_PORT=${TEST_SERVER_PORT:=8880}
 
 ./node_modules/.bin/http-server -p $TEST_SERVER_PORT --silent &
 PID=$!
-node test/runner
+node test/runner $@
 TEST_RUNNER_EXIT=$?
 kill $PID
 

--- a/src/plugins/core/patches/commands/insert-list.js
+++ b/src/plugins/core/patches/commands/insert-list.js
@@ -109,6 +109,19 @@ define([], function () {
         }.bind(this));
       };
 
+      // Explicitly catch unexpected error when calling queryState - bug in Firefox: https://github.com/guardian/scribe/issues/208
+      InsertListCommandPatch.prototype.queryState = function() {
+        try {
+          return scribe.api.CommandPatch.prototype.queryState.apply(this, arguments);
+        } catch (err) {
+          if (err.name == 'NS_ERROR_UNEXPECTED') {
+            return false;
+          } else {
+            throw err;
+          }
+        }
+      };
+
       scribe.commandPatches.insertOrderedList = new InsertListCommandPatch('insertOrderedList');
       scribe.commandPatches.insertUnorderedList = new InsertListCommandPatch('insertUnorderedList');
     };

--- a/src/plugins/core/patches/commands/insert-list.js
+++ b/src/plugins/core/patches/commands/insert-list.js
@@ -109,11 +109,11 @@ define([], function () {
         }.bind(this));
       };
 
-      // Explicitly catch unexpected error when calling queryState - bug in Firefox: https://github.com/guardian/scribe/issues/208
       InsertListCommandPatch.prototype.queryState = function() {
         try {
           return scribe.api.CommandPatch.prototype.queryState.apply(this, arguments);
         } catch (err) {
+          // Explicitly catch unexpected error when calling queryState - bug in Firefox: https://github.com/guardian/scribe/issues/208
           if (err.name == 'NS_ERROR_UNEXPECTED') {
             return false;
           } else {

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -11,6 +11,30 @@ var initializeScribe = helpers.initializeScribe.bind(null, '../../src/scribe');
 var browserBugs = helpers.browserBugs;
 var browserName = helpers.browserName;
 
+var commandQueryState = function(commandName) {
+  return helpers.driver.executeScript(function(commandName) {
+    var command = window.scribe.getCommand(commandName)
+    return command.queryState();
+  }, commandName);
+};
+var commandQueryEnabled = function(commandName) {
+  return helpers.driver.executeScript(function(commandName) {
+    var command = window.scribe.getCommand(commandName)
+    return command.queryEnabled();
+  }, commandName);
+};
+
+// the only way I could get selenium to properly remove focus from scribe, was to type into another field :/
+var focusOther = function() {
+  return helpers.driver.executeScript(function() {
+    var b = document.createElement('input');
+    b.id = 'focusSwitchInput';
+    document.body.appendChild(b);
+  }).then(function() {
+    return helpers.driver.findElement(webdriver.By.id('focusSwitchInput')).sendKeys('!');
+  });
+};
+
 // Get new referenceS each time a new instance is created
 var driver;
 before(function () {
@@ -236,6 +260,43 @@ describe('commands', function () {
         });
       });
     });
+
+    /*
+     * Query command state
+     */
+    givenContentOf('<p>|1</p>', function() {
+      beforeEach(function () {
+        return executeCommand('insertOrderedList');
+      });
+
+      when('the command is executed and queryState is called', function() {
+        it('should return true', function() {
+          return commandQueryState('insertOrderedList').then(function(returnValue) {
+            expect(returnValue).to.be.true;
+          });
+        });
+      });
+
+      when('the command is executed and queryEnabled is called', function() {
+        it('should return true for queryEnabled', function() {
+          return commandQueryEnabled('insertOrderedList').then(function(returnValue) {
+            expect(returnValue).to.be.true;
+          });
+        });
+      });
+    });
+
+    givenContentOf('<p>1</p>', function() {
+      when('queryState is executed for the command', function() {
+        it('should return false', function() {
+          return focusOther().then(function() {
+            return commandQueryState('insertOrderedList');
+          }).then(function(returnValue) {
+            expect(returnValue).to.be.false;
+          });
+        });
+      });
+    });
   });
 
   describe('insertHTML', function () {
@@ -365,7 +426,7 @@ describe('commands', function () {
             });
           });
         });
-        
+
         when('the command is executed with a value of "<p>1<b style="line-height: 2;">2</b><span style="line-height: 2;">3</span></p>"', function () {
           beforeEach(function () {
             // Focus it before-hand
@@ -380,7 +441,7 @@ describe('commands', function () {
             });
           });
         });
-        
+
         when('the command is executed with a value of "<p>1<b style="line-height: 2;">2</b><span style="line-height: 2;">3</span><span style="line-height: 2;">4</span></p>"', function () {
           beforeEach(function () {
             // Focus it before-hand
@@ -395,7 +456,7 @@ describe('commands', function () {
             });
           });
         });
-        
+
         when('the command is executed with a value of "<p><span style="color:green;">1</span></p>"', function () {
           beforeEach(function () {
             // Focus it before-hand

--- a/test/runner.js
+++ b/test/runner.js
@@ -15,13 +15,15 @@ var testEnvironment = require('scribe-test-harness/environment');
 
 var mocha = new Mocha();
 
+var specs = process.argv[2] || (__dirname + '/**/*.spec.js');
+
 /**
  * Wait for the connection to Sauce Labs to finish.
  */
 mocha.timeout(15 * 1000);
 mocha.reporter('spec');
 
-testEnvironment.loadSpecifications(__dirname + '/**/*.spec.js', mocha)
+testEnvironment.loadSpecifications(specs, mocha)
   .then(function(mocha) {
     createRunner(mocha);
   });


### PR DESCRIPTION
Firefox will consistently throw an error when calling `queryCommandState` for `insertUnorderedList` and `insertOrderedList` commands when there's no selection or a contenteditable hasn't got focus. Error as follows:
```
[Exception... "Unexpected error"  nsresult: "0x8000ffff (NS_ERROR_UNEXPECTED)"  location: "JS frame :: debugger eval code :: <TOP_LEVEL> :: line 1"  data: no]
```

`scribe-plugin-toolbar` uses this command to determine the state of the list buttons. The failed call would result in the list command buttons still remaining active when scribe loses focus.

This issue has been recurring for a while in Firefox builds, so it makes sense to catch this until they get around to fixing it, see: https://bugzilla.mozilla.org/show_bug.cgi?id=562623

Fixes #208.

Also, added ability to pass an argument to `run-tests.sh` so you can specify which test specs to run.