### PR TITLE
Restore scribe.element

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -123,6 +123,7 @@ define([
 
   Scribe.prototype = Object.create(EventEmitter.prototype);
   Scribe.prototype.node = nodeHelpers;
+  Scribe.prototype.element= Scribe.prototype.node;
 
   // For plugins
   // TODO: tap combinator?


### PR DESCRIPTION
Alias scribe.element to scribe.node for the benefit of plugins and maintain backwards compatibility (introduced in #404)