### PR TITLE
chore(events): Removed redundant slice of clipboardData.types

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -186,7 +186,7 @@ define([
         if (event.clipboardData) {
           event.preventDefault();
 
-          if (Immutable.List(Array.prototype.slice.call(event.clipboardData.types)).includes('text/html')) {
+          if (Immutable.List(event.clipboardData.types).includes('text/html')) {
             scribe.insertHTML(event.clipboardData.getData('text/html'));
           } else {
             scribe.insertPlainText(event.clipboardData.getData('text/plain'));


### PR DESCRIPTION
Simplifying #405 fix for #401. That should work across all browsers. I'll keep an eye on any issues popping here that might be connected. 