### PR TITLE
Normalize text nodes when removing the markers.

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -138,7 +138,12 @@ define(function () {
 
     Selection.prototype.removeMarkers = function () {
       Array.prototype.forEach.call(this.getMarkers(), function (marker) {
+        var markerParent = marker.parentNode;
         nodeHelpers.removeNode(marker);
+        // Placing the markers may have split a text node. Sew it up, otherwise
+        // if the user presses space between the nodes the browser will insert
+        // an `&nbsp;` and that will cause word wrapping issues.
+        markerParent.normalize();
       });
     };
 


### PR DESCRIPTION
Placing the markers may have split a text node. If we don't sew it up when
removing the markers and the user presses space between the nodes, the browser
will insert an `&nbsp;` and that will cause word wrapping issues.

### Simple way to reproduce the issue:

1. Open http://guardian.github.io/scribe/.
2. Delete the space between "Hello," and "World!".
3. Press space.

Note that there is now an `&nbsp;` between "Hello," and "World!".

### Where this could be a problem:

1. Open http://guardian.github.io/scribe/.
2. Add to the line until it wraps to the second line (resizing your browser window helps) like so: 
![screen shot 2015-07-28 at 5 05 00 pm](https://cloud.githubusercontent.com/assets/110000/8947017/d45a498a-354a-11e5-8cc5-d008e9dbdfd6.png)
3. Press delete at the start of the second line (e.g. before "this" in the screenshot).
4. Press space.

**Expected result**: the word before the deletion e.g. "like" goes back to the first line.
**Actual result**: the word before the deletion stays on the second line.