### PR TITLE
Add event to command

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -160,6 +160,8 @@ define([
 
                 var command = scribe.getCommand(listNode.nodeName === 'OL' ? 'insertOrderedList' : 'insertUnorderedList');
 
+                command.event = event;
+
                 command.execute();
               }
             }


### PR DESCRIPTION
While navigating an ordered list, execute is called when a backspace or enter key is pressed. A plugin might want to know which key was pressed so it can decide how to handle the request. Event has been added to the command.