### PR TITLE
Fix the cjs example

### DIFF
--- a/examples/build-cjs.sh
+++ b/examples/build-cjs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+cd ..
+command -v browserify >/dev/null 2>&1 || { echo >&2 "browserify not installed. run 'npm install -g browserify'. Aborting."; exit 1; }
+npm install deamdify
+npm install scribe-plugin-toolbar
+browserify -g deamdify \
+-r ./bower_components/immutable/dist/immutable.js:immutable \
+-r ./bower_components/lodash-amd/modern/object/assign.js:lodash-amd/modern/object/assign \
+-r ./bower_components/lodash-amd/modern/object/defaults.js:lodash-amd/modern/object/defaults \
+-r ./bower_components/lodash-amd/modern/string/escape.js:lodash-amd/modern/string/escape \
+examples/cjs.js > examples/build.js

--- a/examples/build-cjs.sh
+++ b/examples/build-cjs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 cd ..
 command -v browserify >/dev/null 2>&1 || { echo >&2 "browserify not installed. run 'npm install -g browserify'. Aborting."; exit 1; }
+bower install
 npm install deamdify
 npm install scribe-plugin-toolbar
 browserify -g deamdify \

--- a/examples/cjs.html
+++ b/examples/cjs.html
@@ -6,11 +6,7 @@ Note that you'll need to install scribe's dependencies
 through `npm install`. `npm` is installed with Node.js.
 See http://nodejs.org/ if you are unfamiliar.
 
-In order to compile the `build.js` file, run these commands:
-
-  $ npm install deamdify
-  $ npm install scribe-plugin-toolbar
-  $ browserify -g deamdify examples/cjs.js > examples/build.js
+In order to compile the `build.js` file, run the following file: build-cjs.sh.
 
 See the `examples/cjs.js` file to see the JavaScript logic for this example.
 -->

--- a/examples/cjs.js
+++ b/examples/cjs.js
@@ -7,11 +7,7 @@
  * through `npm install`. `npm` is installed with Node.js.
  * See http://nodejs.org/ if you are unfamiliar.
  *
- * In order to compile the `build.js` file, run these commands:
- *
- *   $ npm install deamdify
- *   $ npm install scribe-plugin-toolbar
- *   $ browserify -g deamdify examples/cjs.js > examples/build.js
+ * In order to compile the `build.js` file, run the following file: build-cjs.sh.
  *
  * See the `examples/cjs.html` file to see where this entry point
  * ends up being consumed.


### PR DESCRIPTION
The common.js example was failing because some dependencies weren't being required by the build steps in the docs. I removed the docs and added a bash script instead that will get the common.js sample working.