### PR TITLE
Add skippable node in MutationObserver

### DIFF
--- a/src/dom-observer.js
+++ b/src/dom-observer.js
@@ -7,7 +7,8 @@ define([
     window.MozMutationObserver;
 
   function hasRealMutation(n) {
-    return ! nodeHelpers.isEmptyTextNode(n) &&
+    return nodeHelpers.isNotObservableNode(n) &&
+      ! nodeHelpers.isEmptyTextNode(n) &&
       ! nodeHelpers.isSelectionMarkerNode(n);
   }
 

--- a/src/node.js
+++ b/src/node.js
@@ -46,6 +46,10 @@ define([
     return (node.nodeType === Node.ELEMENT_NODE && node.className === 'caret-position');
   }
 
+  function isNotObservableNode(node) {
+    return (node.nodeType === Node.ELEMENT_NODE && node.className === 'scribe-not-observable');
+  }
+
   function firstDeepestChild(node) {
     var fs = node.firstChild;
     return !fs || fs.nodeName === 'BR' ?
@@ -152,6 +156,7 @@ define([
     isBefore: isBefore,
     isSelectionMarkerNode: isSelectionMarkerNode,
     isCaretPositionNode: isCaretPositionNode,
+    isNotObservableNode: isNotObservableNode,
     firstDeepestChild: firstDeepestChild,
     insertAfter: insertAfter,
     removeNode: removeNode,


### PR DESCRIPTION
I mount [React](https://facebook.github.io/react/) component inside the Scribe container, whenever the component update it triggers the MutationObserver watching the subtree of the Scribe container. 
Since the component is already encapsulate in the React tree, I don't need this extra re-render from Scribe.