### PR TITLE
Add license to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "scribe-editor",
   "version": "2.1.1",
+  "license": "Apache-2.0",
   "main": "src/scribe.js",
   "dependencies": {
     "lodash-amd": "~3.5.0",


### PR DESCRIPTION
Right now there is no license listed on NPM:

![NPM Screenshot](https://cloud.githubusercontent.com/assets/174864/12452715/e524be38-bf5d-11e5-911f-93030f4c6c31.png)
