### PR TITLE
Node API: remove not-observable check

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -52,10 +52,6 @@ define([
     return elementHasClass(Node, 'caret-position')(node);
   }
 
-  function isNotObservableNode(node) {
-    return elementHasClass(Node, 'scribe-not-observable')(node);
-  }
-
   function isWhitespaceOnlyTextNode(Node, node) {
     if(node.nodeType === Node.TEXT_NODE
       && /^\s*$/.test(node.nodeValue)) {


### PR DESCRIPTION
This function seems to no longer be in use and was not exported so it looks like something that is now redundant.