### PR TITLE
Range API: setStartAfter and setEndAfter only take one parameter

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -102,7 +102,7 @@ define([
              */
             if (headingNode && range.collapsed) {
               var contentToEndRange = range.cloneRange();
-              contentToEndRange.setEndAfter(headingNode, 0);
+              contentToEndRange.setEndAfter(headingNode);
 
               // Get the content from the range to the end of the heading
               var contentToEndFragment = contentToEndRange.cloneContents();

--- a/src/plugins/core/inline-elements-mode.js
+++ b/src/plugins/core/inline-elements-mode.js
@@ -79,7 +79,7 @@ define(function () {
                */
 
               var contentToEndRange = range.cloneRange();
-              contentToEndRange.setEndAfter(scribe.el.lastChild, 0);
+              contentToEndRange.setEndAfter(scribe.el.lastChild);
 
               // Get the content from the range to the end of the heading
               var contentToEndFragment = contentToEndRange.cloneContents();
@@ -93,8 +93,8 @@ define(function () {
 
               var newRange = range.cloneRange();
 
-              newRange.setStartAfter(brNode, 0);
-              newRange.setEndAfter(brNode, 0);
+              newRange.setStartAfter(brNode);
+              newRange.setEndAfter(brNode);
 
               selection.selection.removeAllRanges();
               selection.selection.addRange(newRange);


### PR DESCRIPTION
Resolves #472 by removing the additional parameters from these API calls