### PR TITLE
Remove Unexpected Usage of ES6 const

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,9 +36,9 @@ define(['immutable'], function (immutable) {
 
 
   function defaults(options, defaultOptions) {
-    const optionsCopy = immutable.fromJS(options);
-    const defaultsCopy = immutable.fromJS(defaultOptions);
-    const mergedOptions = defaultsCopy.merge(optionsCopy);
+    var optionsCopy = immutable.fromJS(options);
+    var defaultsCopy = immutable.fromJS(defaultOptions);
+    var mergedOptions = defaultsCopy.merge(optionsCopy);
     return mergedOptions.toJS();
   }
 


### PR DESCRIPTION
- Improves cross-browser support
- Many still don't support ES6 const (eg IE8-E10, http://caniuse.com/#feat=const)
