### PR TITLE
Do not insert `<br>` into custom elements

### DIFF
--- a/src/plugins/core/formatters/html/ensure-selectable-containers.js
+++ b/src/plugins/core/formatters/html/ensure-selectable-containers.js
@@ -50,10 +50,11 @@ define([
     while (node) {
       if (!nodeHelpers.isSelectionMarkerNode(node)) {
         // Find any node that contains no child *elements*, or just contains
-        // whitespace, and is not self-closing
+        // whitespace, is not self-closing and is not a custom element
         if (isEmpty(node) &&
           node.textContent.trim() === '' &&
-          !html5VoidElements.includes(node.nodeName)) {
+          !html5VoidElements.includes(node.nodeName) &&
+          node.nodeName.indexOf('-') === -1) {
           node.appendChild(document.createElement('br'));
         } else if (node.children.length > 0) {
           traverse(node);


### PR DESCRIPTION
I only found tests for formatter in `test-old` but don't know how to run them (they are not running with `npm test`) so no tests this time.

I've started using Scribe with Shadow DOM and custom elements, so expect more PRs in future if there will be any issues:)
