### PR TITLE
fix npm installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "Apache-2.0",
   "main": "src/scribe.js",
   "dependencies": {
-    "immutable": "~3.8.1"
+    "immutable": "~3.8.1",
+    "lodash-amd": "3.5.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
This adds `lodash-npm@3.5.0` as a dependency in `package.json` to match the bower installation.

This will fix #495, but I made the decision to use the obsolete library instead of the polyfill.