### PR TITLE
Debounce input event of editor container

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @infusionsoft/pi

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ AMD syntax example as well as a CommonJS (browserify) example.
   <dd>Defines which of Scribe's built-in plugins should be active</dd>
   <dt><pre>defaultFormatters</pre></dt>
   <dd>Defines which of Scribe's default formatters should be active</dd>
+  <dt><pre>inputDelay</pre></dt>
+  <dd>Defines the debounce delay for input events on editor container (default is 0)</dd>
 </dl>
 
 For detailed documentation see the [wiki page on options](https://github.com/guardian/scribe/wiki/Scribe-configuration-options).

--- a/src/config.js
+++ b/src/config.js
@@ -31,7 +31,9 @@ define(['immutable'], function (immutable) {
     defaultFormatters: [
       'escapeHtmlCharactersFormatter',
       'replaceNbspCharsFormatter'
-    ]
+    ],
+
+    inputDelay: 0
   };
 
 

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,0 +1,26 @@
+define([], function () {
+  return function (func, wait, immediate) {
+    var timeout;
+
+    return function () {
+      var context = this, args = arguments;
+
+      var later = function () {
+        timeout = null;
+
+        if (!immediate) {
+          func.apply(context, args);
+        }
+      };
+
+      var callNow = immediate && !timeout;
+
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+
+      if (callNow) {
+        func.apply(context, args);
+      }
+    };
+  };
+});

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -11,7 +11,8 @@ define([
   './node',
   'immutable',
   './config',
-  './events'
+  './events',
+  './debounce'
 ], function (
   plugins,
   commands,
@@ -25,13 +26,16 @@ define([
   nodeHelpers,
   Immutable,
   config,
-  eventNames
+  eventNames,
+  debounce
 ) {
 
   'use strict';
 
   function Scribe(el, options) {
     EventEmitter.call(this);
+
+    var INPUT_DELAY = 300;
 
     this.el = el;
     this.commands = {};
@@ -68,7 +72,7 @@ define([
 
     this.el.setAttribute('contenteditable', true);
 
-    this.el.addEventListener('input', function () {
+    this.el.addEventListener('input', debounce(function () {
       /**
        * This event triggers when either the user types something or a native
        * command is executed which causes the content to change (i.e.
@@ -76,7 +80,7 @@ define([
        * these actions, so instead we run the transaction in this event.
        */
       this.transactionManager.run();
-    }.bind(this), false);
+    }.bind(this), INPUT_DELAY).bind(this), false);
 
     /**
      * Core Plugins

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -35,8 +35,6 @@ define([
   function Scribe(el, options) {
     EventEmitter.call(this);
 
-    var INPUT_DELAY = 300;
-
     this.el = el;
     this.commands = {};
 
@@ -80,7 +78,7 @@ define([
        * these actions, so instead we run the transaction in this event.
        */
       this.transactionManager.run();
-    }.bind(this), INPUT_DELAY).bind(this), false);
+    }.bind(this), this.options.inputDelay).bind(this), false);
 
     /**
      * Core Plugins


### PR DESCRIPTION
This allows Mac users to type accented characters (e.g. - `Option` + `n` to produce an ñ) when using Scribe along with HTML Janitor.