### PR TITLE
Fix Scribe adding links to other contenteditables

### DIFF
--- a/src/plugins/core/patches/commands/create-link.js
+++ b/src/plugins/core/patches/commands/create-link.js
@@ -11,6 +11,14 @@ define(function () {
         var selection = new scribe.api.Selection();
 
         /**
+         * make sure we're not touching any none Scribe elements
+         * in the page
+         */
+        if (!scribe.api.Selection().isInScribe()) {
+          return;
+        }
+
+        /**
          * Firefox does not create a link when selection is collapsed
          * so we create it manually. http://jsbin.com/tutufi/2/edit?js,output
          */


### PR DESCRIPTION
This PR stops Scribe throwing it's links around into other contenteditable nodes. This probably could be widened to ignore any commands when Scribe doesn't have a selection or focus, but the surface area of this PR would increase by a factor of 100 and I have no idea what it might break.