### PR TITLE
fix creating selection range when endNode contains startNode (#526)

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -71,7 +71,7 @@ define(function () {
           endOffset = tmp;
         }
         // if the range ends *before* it starts, then we must reverse the range
-        else if (nodeHelpers.isBefore(endNode, startNode)) {
+        else if (nodeHelpers.isBefore(endNode, startNode) && !endNode.contains(startNode)) {
           var tmpNode = startNode,
             tmpOffset = startOffset;
           startNode = endNode;


### PR DESCRIPTION
fixes #526 by also checking that the endNode isn't an ancestor of startNode before reversing the selection range